### PR TITLE
docs: codify workflow and validation playbooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+
+jobs:
+  lint-and-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Build devcontainer image
+        run: docker compose build devcontainer
+
+      - name: Install dev dependencies in container
+        run: docker compose run --rm devcontainer poetry install --with dev
+
+      - name: Run Ruff lint checks
+        run: docker compose run --rm devcontainer poetry run ruff check .
+
+      - name: Run Ruff format check
+        run: docker compose run --rm devcontainer poetry run ruff format --check .
+
+      - name: Build runtime image
+        run: docker compose build app

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,76 @@
+name: Publish Image
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish-runtime-image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Compute image tags
+        id: tags
+        env:
+          REPOSITORY: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        run: |
+          image="ghcr.io/${REPOSITORY,,}"
+          short_sha="${GITHUB_SHA::12}"
+
+          tags="${image}:sha-${short_sha}"
+          push="true"
+
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            tags="${tags},${image}:pr${PR_NUMBER}"
+            if [ "${PR_HEAD_REPO}" != "${REPOSITORY}" ]; then
+              push="false"
+            fi
+          else
+            branch_tag="$(printf '%s' "${REF_NAME}" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9._-' '-')"
+            tags="${tags},${image}:${branch_tag}"
+            if [ "${REF_NAME}" = "main" ]; then
+              tags="${tags},${image}:latest"
+            fi
+          fi
+
+          {
+            echo "image=${image}"
+            echo "tags=${tags}"
+            echo "push=${push}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Log in to GitHub Container Registry
+        if: steps.tags.outputs.push == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish runtime image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          target: runtime
+          push: ${{ steps.tags.outputs.push == 'true' }}
+          tags: ${{ steps.tags.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - Start with `README.md`, `CONTRIBUTING.md`, `docs/rfcs/0001-canonical-graph-authority-and-hcl.md`, `docs/rfcs/0002-operational-plane-and-deployment-topology.md`, `docs/rfcs/0003-1x-carry-over-concepts.md`, `docs/rfcs/0004-netbox-projector-carry-over-concepts.md`, `docs/rfcs/0005-run-job-task-and-lease-state-model.md`, `docs/rfcs/0006-collector-api-contract.md`, and `docs/rfcs/0007-projection-plan-and-result-artifact-contract.md`.
 - Use `docs/architecture/ARCHITECTURE.md` for a fast system-level summary, but treat the RFCs as authoritative.
 - Treat `docs/rfcs/` as normative architecture. `docs/architecture/` is informative. `docs/ROADMAP.md` is planning guidance only, not a compatibility promise.
+- Use `docs/development/` playbooks for repeated implementation, validation, and review workflows.
 
 ## Current Repo State
 
@@ -12,6 +13,16 @@
 - Python is pinned to `^3.12`. Use Poetry inside the devcontainer for orchestration and Ruff for linting/formatting.
 - `tool.poetry.package-mode = false` right now. Do not assume there is already an installable package or entrypoint.
 - Do not run `poetry` on the host machine for normal repo work. Keep Poetry environments and installs inside the devcontainer flow.
+
+## Delivery Workflow
+
+- This repository is human-in-the-loop: agents assist, but humans remain the final authority for review, merge, and acceptance.
+- Work issue-first.
+- Use a dedicated clean branch and isolated workspace or worktree per issue.
+- Keep commits small and reviewable.
+- Build unit tests alongside code changes; do not treat tests as a later cleanup pass.
+- Do not merge until CI, review gates, and runtime evidence checks are satisfied.
+- When runtime behavior changes, validate using API-retrieved artifacts and status rather than direct database inspection.
 
 ## Verified Commands
 
@@ -24,6 +35,7 @@
 - The devcontainer runs `poetry install --with dev` on create.
 - Poetry virtualenvs are stored in the container volume mounted at `/opt/poetry-venvs`, not in the repo checkout.
 - The `devcontainer` service uses a bind mount for live repo edits. The `app` runtime image copies the repo into `/workspace` at build time and does not use the dev bind mount.
+- GitHub Actions should validate lint/build on commits and publish runtime images tagged by PR number or branch name, with `latest` for `main`.
 - There is still no verified root test or typecheck command until those tools are added to config.
 
 ## Architecture Guardrails
@@ -38,6 +50,8 @@
 - Projection planning belongs in the API/core. Projection execution should be deployable separately by default, even if early artifact projection runs in-process.
 - For the NetBox projector, preserve execution-side patterns like a `pynetbox` wrapper, Redis-backed lookup caching, idempotent ensure-style writes, and dependency-aware execution ordering, but keep them inside the projector boundary.
 - Projection planning should emit durable plan artifacts, and projection execution should emit durable result artifacts rather than relying on ad hoc payloads.
+- Runtime artifacts should be retrievable through the API during development and validation; do not assume direct database inspection is the normal debugging path.
+- Preserve strong debug instrumentation at each stage so collector activity, authority resolution, projection planning, and projection execution can be explained from API-visible state.
 - Source-local assembly is allowed inside adapters, but that private assembly state must not become a public schema consumed elsewhere.
 - Do not hardcode source precedence or authority decisions in adapter code. Authority belongs in declarative HCL policy.
 - Keep the core projection-neutral. Projectors consume resolved canonical truth downstream; adapters must not emit target-specific payloads.
@@ -46,7 +60,7 @@
 
 - Prefer small foundational changes and minimal dependencies.
 - The current docs explicitly bias early implementation toward standard library `dataclasses`, not framework-driven architecture.
-- If you add code before more guidance exists, stay aligned with the documented build order: core enums/literals, dataclass models, graph invariant validation, authority resolution, artifact/JSON projection, then minimal HCL parsing.
+- If you add code before more guidance exists, stay aligned with the documented build order: core enums/literals, dataclass models, graph invariant validation, minimal run/job/lease control-plane types, repository and API queue/claim substrate, authority resolution, projection artifacts and artifact/JSON projection, then minimal HCL parsing.
 - Avoid building UI, scheduler, persistence, or broader control-plane/runtime concerns before the canonical core is stable.
 
 ## RFC-First Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,10 @@
 
 This repository is a `2.0` rewrite built from architecture-first decisions.
 
+It should also be treated as a human-in-the-loop development environment where
+agents assist implementation and validation, but humans remain the final
+authority for review, merge, and acceptance.
+
 Contributors should assume:
 
 - the canonical graph is the center of the system
@@ -48,6 +52,49 @@ Early commits should stay focused:
 
 - one architectural document or tightly related document set per commit
 - one implementation concern per commit once code begins
+
+## Issue-First Delivery Workflow
+
+Development should be issue-first.
+
+Expected workflow:
+
+1. start from a GitHub issue
+2. use a dedicated clean branch and isolated workspace or worktree for that issue
+3. keep changes focused and incrementally reviewable
+4. build unit tests alongside the code instead of deferring them
+5. open a PR early and keep a steady review/update cycle
+
+PRs should prefer small, coherent commits over large batch drops.
+
+## Merge Gates
+
+Merge should not occur until all of the following are true:
+
+- CI checks are green
+- required code review gates are satisfied
+- relevant unit tests are present for the change
+- runtime evidence has been retrieved through API-visible artifacts or status
+  endpoints when the change affects runtime behavior
+
+Direct database inspection is not the normal validation path.
+
+## CI And Image Publishing
+
+The repository should maintain GitHub Actions for both validation and image
+publishing.
+
+Current policy:
+
+- commits should trigger CI validation
+- commits should trigger runtime image builds
+- PR builds should publish a PR-tagged image such as `:pr1234`
+- branch builds should publish a branch-tagged image such as `:dev` or
+  `:release-1.1`
+- `main` should also publish `:latest`
+
+These tags should represent the current state of the work under review so the
+result can be exercised before merge.
 
 ## Testing Philosophy
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ Code should follow those documents, not invent a parallel architecture.
   - informative system-level architecture summary across the RFC set
 - `docs/architecture/IMPLEMENTATION_OUTLINE.md`
   - initial implementation companion and milestone framing
+- `docs/development/HUMAN_IN_THE_LOOP.md`
+  - human/agent collaboration model for this repository
+- `docs/development/COLLECTOR_WORKFLOW.md`
+  - collector implementation playbook
+- `docs/development/PROJECTOR_WORKFLOW.md`
+  - projector implementation playbook
+- `docs/development/RUNTIME_VALIDATION.md`
+  - API-first runtime validation playbook
+- `docs/development/CODE_REVIEW_STANDARD.md`
+  - review and merge-readiness playbook
 - `docs/ROADMAP.md`
   - milestone roadmap
 - `CONTRIBUTING.md`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,49 +23,68 @@
 - projection declaration shape
 - minimal parser contract
 
-## Milestone 3: Ingest Pipeline
+## Milestone 3: Minimal Operational Substrate
+
+- `run`, `job`, `task`, `lease`, `heartbeat`, and `result` state model
+- repository abstractions for canonical and control-plane persistence
+- collector check-in / claim / heartbeat API contract
+- minimal API queueing and leasing behavior
+- minimal worker loop for run and job creation
+
+## Milestone 4: Ingest Pipeline
 
 - adapter output contract
 - canonical graph ingestion pipeline
 - source-local assembly guidance
 - graph artifact serialization
 
-## Milestone 4: Authority Resolver
+## Milestone 5: Authority Resolver
 
 - scope/category authority ranking
 - confidence-based ordering
 - mode semantics: replace, fill_if_missing, merge, observe_only
 - provenance preservation
 
-## Milestone 5: Projection Framework
+## Milestone 6: Projection Framework
 
 - projector interfaces
 - projection planning contract
 - artifact/JSON projector
 
-## Milestone 6: First Target Projector
+## Milestone 7: First Target Projector
 
 - initial NetBox projector
 - explicit target-lossiness notes
 - target mapping tests against canonical graph inputs
 
-## Milestone 7: First Source Adapters
+## Milestone 8: First Source Adapters
 
 - one simple source
 - one fragmented source
 - one enrichment-focused source
 
-## Milestone 8: Cross-Source Enrichment Validation
+## Milestone 9: Cross-Source Enrichment Validation
 
 - `xclarity + vmware + nexus`
 - `vmware + salt`
 - `catc/nexus + supplemental source`
 
-## Milestone 9: Operational Plane
+## Milestone 10: Web UI Foundations
+
+- API-only web application shell
+- run / job / lease status views
+- basic artifact and result inspection
+- initial canonical graph browsing views
+
+## Milestone 11: Expanded Operational Plane
 
 - CLI shape
-- batch/run orchestration
-- persistence/runtime concerns
-- control-plane design
+- richer batch/run orchestration
+- deeper persistence/runtime concerns
+- advanced control-plane behavior and housekeeping
 
-This milestone is intentionally later. The canonical core comes first.
+The canonical core still comes first, but the minimal operational substrate is
+now intentionally earlier so ingest, collectors, and later projection work can
+build on a shared API-owned run/job/lease framework. The UI should start after
+that minimal substrate exists, but as its own API-only milestone rather than as
+part of the substrate itself.

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -58,6 +58,7 @@ It owns:
 - authority resolution
 - projection planning
 - run and job state transitions
+- runtime artifact retrieval for development and operator validation
 - data access for the UI
 
 ### Worker
@@ -175,6 +176,13 @@ Two artifact families are important:
 Projection planning should emit durable plan artifacts.
 
 Projection execution should emit durable result artifacts.
+
+Development and validation flows should retrieve runtime artifacts through the
+API rather than relying on direct database inspection.
+
+Debug instrumentation is expected at each stage so artifact inspection can
+explain collector behavior, resolution outcomes, plan generation, and execution
+results.
 
 ## Persistence Model
 

--- a/docs/architecture/IMPLEMENTATION_OUTLINE.md
+++ b/docs/architecture/IMPLEMENTATION_OUTLINE.md
@@ -88,20 +88,20 @@ Keep boundaries clear between:
 1. core enums / literal sets for scopes, categories, tiers, modes
 2. dataclass models for node, edge, claim, graph artifact
 3. graph invariant validation helpers
-4. authority resolution engine
-5. projection plan and result artifact models
-6. artifact/JSON projection planning and execution
-7. minimal HCL parsing for source authority and projection declarations
-8. control-plane dataclasses for run, job, task, lease, heartbeat, and result
-9. repository abstractions for canonical and control-plane persistence
-10. minimal API application boundary around ingestion, authority resolution,
-    queueing, and projection planning
-11. collector API contract implementation for check-in, claim, heartbeat, graph
-    submission, and result submission
-12. minimal worker loop that creates runs/jobs through the API
+4. control-plane dataclasses for run, job, task, lease, heartbeat, and result
+5. repository abstractions for canonical and control-plane persistence
+6. minimal API application boundary around ingestion, queueing, and claiming
+7. collector API contract implementation for check-in, claim, heartbeat, graph
+   submission, and result submission
+8. minimal worker loop that creates runs/jobs through the API
+9. authority resolution engine
+10. projection plan and result artifact models
+11. artifact/JSON projection planning and execution
+12. minimal HCL parsing for source authority and projection declarations
 
-This order is intentionally biased toward proving canonical and projection
-contracts before building broader runtime orchestration.
+This order is intentionally biased toward proving canonical contracts first,
+then introducing the smallest shared operational substrate before building
+ingest, collector, and projection flows on top of it.
 
 ## Source Adapter Expectations
 

--- a/docs/development/CODE_REVIEW_STANDARD.md
+++ b/docs/development/CODE_REVIEW_STANDARD.md
@@ -1,0 +1,39 @@
+# Code Review Standard
+
+Use this playbook when preparing changes for review or reviewing agent-produced
+work.
+
+## Review Priorities
+
+Review should focus first on:
+
+- correctness
+- architectural boundary violations
+- missing tests
+- runtime validation gaps
+- regressions in API-visible behavior or artifact contracts
+
+## Expected Change Shape
+
+Good reviewable changes are usually:
+
+- issue-scoped
+- small to moderate in size
+- accompanied by tests when behavior changes
+- accompanied by RFC or doc updates when contracts change
+
+## Merge Expectations
+
+Before merge, expect:
+
+- CI green
+- code review complete
+- unit tests added or updated as needed
+- runtime evidence retrieved when behavior changes
+
+## Red Flags
+
+- target-specific logic leaking into canonical core
+- hidden precedence logic in adapter or collector code
+- direct database access used for UI or normal runtime validation
+- large unstructured commits with weak evidence

--- a/docs/development/COLLECTOR_WORKFLOW.md
+++ b/docs/development/COLLECTOR_WORKFLOW.md
@@ -1,0 +1,36 @@
+# Collector Workflow
+
+Use this playbook when implementing or modifying collector behavior.
+
+## Core Rules
+
+- collectors are remote deployable services, not direct database writers
+- collectors emit canonical nodes, edges, and claims only
+- collectors use API-mediated check-in, claim, heartbeat, submission, and result
+  reporting
+- collectors do not resolve authority and do not perform projection
+
+## Implementation Checklist
+
+1. confirm the collector change aligns with RFC `0002`, `0005`, and `0006`
+2. keep source-local assembly private to the adapter
+3. ensure public output is canonical graph data only
+4. ensure runtime status and artifacts are retrievable through the API
+5. add tests for both canonical emission and control-plane behavior where
+   relevant
+
+## Validation Expectations
+
+Preferred validation evidence:
+
+- API-visible collector check-in state
+- API-visible claimed job / lease state
+- canonical graph submission artifact retrieval
+- result submission status
+
+## Common Mistakes To Avoid
+
+- leaking source-private schemas into public contracts
+- bypassing API queue or lease behavior
+- embedding source precedence logic in collector code
+- validating only through database inspection

--- a/docs/development/HUMAN_IN_THE_LOOP.md
+++ b/docs/development/HUMAN_IN_THE_LOOP.md
@@ -1,0 +1,61 @@
+# Human-In-The-Loop Development
+
+This repository should be treated as a human-in-the-loop project.
+
+That means agents assist with implementation, validation, and documentation, but
+they are not the final authority on architecture, merge decisions, or runtime
+acceptance.
+
+## Working Model
+
+The intended loop is:
+
+1. a human defines or confirms the issue and desired outcome
+2. an agent implements focused changes and updates related tests/docs
+3. the agent reports what changed, what was verified, and what still needs human
+   judgment
+4. a human reviews the code, runtime evidence, and CI results
+5. merge happens only after the human review and repo gates are satisfied
+
+## What Agents Should Optimize For
+
+Agents working in this repo should optimize for:
+
+- small, reviewable changes
+- explicit assumptions
+- API-visible runtime validation
+- strong debug instrumentation
+- preserving architectural boundaries from the RFCs
+
+## What Should Still Require Human Judgment
+
+The following should not be treated as purely agent-autonomous decisions:
+
+- architectural direction changes
+- milestone or scope changes
+- merge readiness
+- interpretation of ambiguous production/runtime evidence
+- security-sensitive deployment choices
+
+## Validation Standard
+
+When runtime behavior changes, the preferred evidence path is:
+
+- CI results
+- unit/integration test results
+- API-retrieved run, job, lease, and artifact state
+- projector or collector result artifacts
+
+Direct database inspection is not the primary acceptance path.
+
+## Review Standard
+
+Agent work should be easy for a human reviewer to inspect.
+
+That implies:
+
+- issue-first changes
+- dedicated branch or worktree per issue
+- small commits
+- linked docs/RFC updates when contracts change
+- clear summary of what was implemented and how it was verified

--- a/docs/development/PROJECTOR_WORKFLOW.md
+++ b/docs/development/PROJECTOR_WORKFLOW.md
@@ -1,0 +1,39 @@
+# Projector Workflow
+
+Use this playbook when implementing projection planning or execution behavior.
+
+## Core Rules
+
+- projection planning belongs in the API/core
+- projection execution belongs in projector-side logic
+- projectors consume resolved canonical truth downstream
+- target-specific behavior must not redefine canonical truth or authority rules
+
+## Implementation Checklist
+
+1. confirm the change aligns with RFC `0002`, `0004`, and `0007`
+2. decide whether the work belongs in planning or execution
+3. preserve durable plan and result artifact boundaries
+4. keep target-specific helpers inside the projector boundary
+5. add tests for plan generation, ordering, and result reporting
+
+## NetBox-Specific Reminders
+
+- prefer the projector-local `pynetbox` wrapper
+- use cache-backed lookup helpers where appropriate
+- preserve idempotent ensure-style write behavior
+- keep dependency-aware ordering explicit
+
+## Validation Expectations
+
+Preferred validation evidence:
+
+- API-retrieved projection plan artifacts
+- API-retrieved projection result artifacts
+- clear result metrics such as created, updated, skipped, and failed
+
+## Common Mistakes To Avoid
+
+- moving truth resolution into projector code
+- using ad hoc payloads instead of artifact contracts
+- letting NetBox-shaped execution needs leak into canonical models

--- a/docs/development/RUNTIME_VALIDATION.md
+++ b/docs/development/RUNTIME_VALIDATION.md
@@ -1,0 +1,30 @@
+# Runtime Validation
+
+Use this playbook when validating behavior that touches collectors, API queueing,
+authority resolution, or projection execution.
+
+## Default Principle
+
+Validation should be API-first.
+
+Preferred evidence comes from:
+
+- run, job, lease, and result state exposed through the API
+- collector graph artifacts
+- projection plan artifacts
+- projection result artifacts
+- structured debug instrumentation
+
+## Normal Validation Flow
+
+1. run the relevant unit and integration checks
+2. inspect API-visible run and job state
+3. retrieve related runtime artifacts through the API
+4. review stage-level instrumentation for explanation, not just status
+5. summarize what was proven and what remains uncertain
+
+## Avoid
+
+- relying on direct database inspection as the primary check
+- treating a successful process exit as enough evidence
+- skipping artifact retrieval when the change affects runtime behavior

--- a/docs/rfcs/0002-operational-plane-and-deployment-topology.md
+++ b/docs/rfcs/0002-operational-plane-and-deployment-topology.md
@@ -81,6 +81,7 @@ It should own:
 - persistence through repository abstractions
 - projection planning
 - job state transitions
+- runtime artifact retrieval for operators and development validation
 - exposure of data for the UI and operators
 
 It should not own:
@@ -139,6 +140,22 @@ control path.
 
 For `v0`, API-mediated behavior is preferred because it keeps business rules in
 one place even if it is less optimized.
+
+## 9.1 Validation And Debugging Principle
+
+Runtime validation and debugging should be API-first.
+
+That means:
+
+- runtime artifacts should be retrievable through the API during development
+  and validation
+- operators and developers should not need direct database access to inspect run
+  state, graph artifacts, projection plans, or projection results
+- each stage should emit enough structured debug instrumentation to explain what
+  happened and why
+
+This principle applies to collector submissions, authority resolution,
+projection planning, and projection execution.
 
 ## 10. Collector Service
 

--- a/docs/rfcs/0007-projection-plan-and-result-artifact-contract.md
+++ b/docs/rfcs/0007-projection-plan-and-result-artifact-contract.md
@@ -182,6 +182,10 @@ The operational model should support:
 This allows run history and troubleshooting without embedding full artifacts in
 every status row.
 
+Artifact retrieval should be API-accessible so development and validation flows
+can inspect plan and result artifacts without depending on direct database or
+storage access.
+
 ## 15. Relationship To Canonical Artifacts
 
 Projection artifacts are downstream from canonical graph artifacts.
@@ -207,4 +211,6 @@ stable.
 - projection execution emits durable result artifacts
 - execution units are planner-defined and executor-consumed
 - dry-run is a first-class artifact mode
+- projection artifacts should be retrievable through the API for validation and
+  debugging
 - projection artifacts remain downstream operational records, not canonical truth


### PR DESCRIPTION
## Summary
- document the human-in-the-loop, issue-first delivery workflow and merge gates
- add development playbooks for collectors, projectors, runtime validation, and code review
- add GitHub Actions for CI validation and GHCR image publishing, and update roadmap sequencing for early operational substrate plus UI foundations

## Validation
- not run locally beyond document/workflow consistency checks

Closes #32