### PR TITLE
docs: codify dev-based branching workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,8 @@
 - This repository is human-in-the-loop: agents assist, but humans remain the final authority for review, merge, and acceptance.
 - Work issue-first.
 - Use a dedicated clean branch and isolated workspace or worktree per issue.
+- Start normal implementation branches from `dev`, not `main`.
+- Use typed branch prefixes such as `feature/`, `bugfix/`, `chore/`, `docs/`, `refactor/`, and `test/`.
 - Keep commits small and reviewable.
 - Build unit tests alongside code changes; do not treat tests as a later cleanup pass.
 - Do not merge until CI, review gates, and runtime evidence checks are satisfied.
@@ -36,6 +38,7 @@
 - Poetry virtualenvs are stored in the container volume mounted at `/opt/poetry-venvs`, not in the repo checkout.
 - The `devcontainer` service uses a bind mount for live repo edits. The `app` runtime image copies the repo into `/workspace` at build time and does not use the dev bind mount.
 - GitHub Actions should validate lint/build on commits and publish runtime images tagged by PR number or branch name, with `latest` for `main`.
+- Prefer the published GHCR branch image such as `ghcr.io/clemson-netbox/canonical-discovery:dev` when validating the integrated development environment.
 - There is still no verified root test or typecheck command until those tools are added to config.
 
 ## Architecture Guardrails

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,10 +60,17 @@ Development should be issue-first.
 Expected workflow:
 
 1. start from a GitHub issue
-2. use a dedicated clean branch and isolated workspace or worktree for that issue
-3. keep changes focused and incrementally reviewable
-4. build unit tests alongside the code instead of deferring them
-5. open a PR early and keep a steady review/update cycle
+2. branch from `dev`, not `main`, for normal issue work
+3. use a dedicated clean branch and isolated workspace or worktree for that issue
+4. use a typed branch prefix such as `feature/`, `bugfix/`, `chore/`, `docs/`, `refactor/`, or `test/`
+5. keep changes focused and incrementally reviewable
+6. build unit tests alongside the code instead of deferring them
+7. open a PR early and keep a steady review/update cycle
+
+Normal implementation PRs should target `dev`.
+
+`main` should remain the stable branch and receive reviewed integration work
+rather than serving as the default base for issue branches.
 
 PRs should prefer small, coherent commits over large batch drops.
 
@@ -89,12 +96,16 @@ Current policy:
 - commits should trigger CI validation
 - commits should trigger runtime image builds
 - PR builds should publish a PR-tagged image such as `:pr1234`
+- the `dev` integration branch should publish a `:dev` image for shared validation
 - branch builds should publish a branch-tagged image such as `:dev` or
   `:release-1.1`
 - `main` should also publish `:latest`
 
 These tags should represent the current state of the work under review so the
 result can be exercised before merge.
+
+When validating the integrated development environment, prefer the published
+GHCR branch image over ad hoc local rebuilds when practical.
 
 ## Testing Philosophy
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Code should follow those documents, not invent a parallel architecture.
   - initial implementation companion and milestone framing
 - `docs/development/HUMAN_IN_THE_LOOP.md`
   - human/agent collaboration model for this repository
+- `docs/development/BRANCHING_WORKFLOW.md`
+  - branch roles, naming, and PR target workflow
 - `docs/development/COLLECTOR_WORKFLOW.md`
   - collector implementation playbook
 - `docs/development/PROJECTOR_WORKFLOW.md`

--- a/docs/development/BRANCHING_WORKFLOW.md
+++ b/docs/development/BRANCHING_WORKFLOW.md
@@ -1,0 +1,50 @@
+# Branching Workflow
+
+Use this playbook for normal repository development.
+
+## Branch Roles
+
+- `main` is the stable branch
+- `dev` is the integration branch for active development
+- normal issue work should branch from `dev`, not from `main`
+
+## Branch Naming
+
+Use a typed branch prefix so the purpose of the branch is obvious.
+
+Preferred prefixes:
+
+- `feature/`
+- `bugfix/`
+- `chore/`
+- `docs/`
+- `refactor/`
+- `test/`
+
+Include the issue number when practical.
+
+Examples:
+
+- `feature/issue-17-simple-source-adapter`
+- `bugfix/issue-42-lease-expiry-state`
+- `chore/issue-34-branching-workflow`
+
+## Pull Request Targets
+
+- normal implementation PRs should target `dev`
+- `main` should receive reviewed and validated integration work rather than
+  being the default base for issue branches
+
+## Image Validation
+
+The integrated branch image should come from the published registry build.
+
+For shared validation of the current integrated environment, prefer the
+published GHCR image for `dev`, such as:
+
+- `ghcr.io/clemson-netbox/canonical-discovery:dev`
+
+Branch and PR builds may also publish review-specific tags such as `:pr1234`.
+
+Use local rebuilds when needed, but prefer the published branch image when the
+goal is to validate what CI built for the current integrated branch state.

--- a/docs/development/CODE_REVIEW_STANDARD.md
+++ b/docs/development/CODE_REVIEW_STANDARD.md
@@ -18,6 +18,7 @@ Review should focus first on:
 Good reviewable changes are usually:
 
 - issue-scoped
+- based on a dedicated branch from `dev`
 - small to moderate in size
 - accompanied by tests when behavior changes
 - accompanied by RFC or doc updates when contracts change

--- a/docs/development/HUMAN_IN_THE_LOOP.md
+++ b/docs/development/HUMAN_IN_THE_LOOP.md
@@ -55,6 +55,7 @@ Agent work should be easy for a human reviewer to inspect.
 That implies:
 
 - issue-first changes
+- issue branches from `dev` for normal implementation work
 - dedicated branch or worktree per issue
 - small commits
 - linked docs/RFC updates when contracts change


### PR DESCRIPTION
## Summary
- document `dev` as the integration branch and `main` as the stable branch
- add typed branch prefix guidance and a dedicated branching workflow playbook
- document preference for the published GHCR `:dev` image when validating the integrated environment

## Validation
- documentation-only change

Closes #34