### PR TITLE
feat: define canonical core enums

### DIFF
--- a/src/canonical_discovery/__init__.py
+++ b/src/canonical_discovery/__init__.py
@@ -1,0 +1,1 @@
+"""Top-level package for canonical-discovery."""

--- a/src/canonical_discovery/core/__init__.py
+++ b/src/canonical_discovery/core/__init__.py
@@ -1,0 +1,17 @@
+"""Canonical core types and helpers."""
+
+from canonical_discovery.core.enums import (
+    AuthorityMode,
+    AuthorityTier,
+    Category,
+    EdgeType,
+    NodeScope,
+)
+
+__all__ = [
+    "AuthorityMode",
+    "AuthorityTier",
+    "Category",
+    "EdgeType",
+    "NodeScope",
+]

--- a/src/canonical_discovery/core/enums.py
+++ b/src/canonical_discovery/core/enums.py
@@ -1,0 +1,64 @@
+"""Core enum definitions fixed by the architecture RFCs."""
+
+from enum import StrEnum
+
+
+class NodeScope(StrEnum):
+    """Canonical node scopes defined by RFC 0001."""
+
+    PHYSICAL_DEVICE = "physical_device"
+    DEVICE_COMPONENT = "device_component"
+    PORT = "port"
+    LINK = "link"
+    IP_ADDRESS = "ip_address"
+    NETWORK_SEGMENT = "network_segment"
+    VIRTUAL_MACHINE = "virtual_machine"
+    OS_INSTANCE = "os_instance"
+    LOCATION = "location"
+
+
+class EdgeType(StrEnum):
+    """Canonical edge types defined by RFC 0001."""
+
+    CONTAINS = "contains"
+    HOSTS = "hosts"
+    CONNECTED_TO = "connected_to"
+    MEMBER_OF = "member_of"
+    ASSIGNED_TO = "assigned_to"
+    LOCATED_IN = "located_in"
+    BACKS = "backs"
+    OBSERVED_BY = "observed_by"
+
+
+class Category(StrEnum):
+    """Canonical categories used for authority policy in RFC 0001."""
+
+    IDENTITY = "identity"
+    HARDWARE_INVENTORY = "hardware_inventory"
+    MODULE_INVENTORY = "module_inventory"
+    VIRTUALIZATION = "virtualization"
+    OPERATING_SYSTEM = "operating_system"
+    NETWORK_L1_L2 = "network_l1_l2"
+    NETWORK_L3 = "network_l3"
+    TOPOLOGY = "topology"
+    PLACEMENT = "placement"
+    OWNERSHIP_CONTEXT = "ownership_context"
+    TELEMETRY = "telemetry"
+
+
+class AuthorityTier(StrEnum):
+    """Authority tiers defined by RFC 0001."""
+
+    AUTHORITATIVE = "authoritative"
+    PREFERRED = "preferred"
+    SUPPLEMENTAL = "supplemental"
+    OBSERVE_ONLY = "observe_only"
+
+
+class AuthorityMode(StrEnum):
+    """Authority modes defined by RFC 0001."""
+
+    REPLACE = "replace"
+    FILL_IF_MISSING = "fill_if_missing"
+    MERGE = "merge"
+    OBSERVE_ONLY = "observe_only"

--- a/tests/test_core_enums.py
+++ b/tests/test_core_enums.py
@@ -1,0 +1,95 @@
+"""Tests for core enum definitions fixed by the RFCs."""
+
+from __future__ import annotations
+
+import unittest
+
+from canonical_discovery.core import AuthorityMode, AuthorityTier, Category, EdgeType, NodeScope
+
+
+def enum_values(enum_type: type) -> list[str]:
+    return [member.value for member in enum_type]
+
+
+class NodeScopeTests(unittest.TestCase):
+    def test_node_scope_values_match_rfc(self) -> None:
+        self.assertEqual(
+            enum_values(NodeScope),
+            [
+                "physical_device",
+                "device_component",
+                "port",
+                "link",
+                "ip_address",
+                "network_segment",
+                "virtual_machine",
+                "os_instance",
+                "location",
+            ],
+        )
+
+
+class EdgeTypeTests(unittest.TestCase):
+    def test_edge_type_values_match_rfc(self) -> None:
+        self.assertEqual(
+            enum_values(EdgeType),
+            [
+                "contains",
+                "hosts",
+                "connected_to",
+                "member_of",
+                "assigned_to",
+                "located_in",
+                "backs",
+                "observed_by",
+            ],
+        )
+
+
+class CategoryTests(unittest.TestCase):
+    def test_category_values_match_rfc(self) -> None:
+        self.assertEqual(
+            enum_values(Category),
+            [
+                "identity",
+                "hardware_inventory",
+                "module_inventory",
+                "virtualization",
+                "operating_system",
+                "network_l1_l2",
+                "network_l3",
+                "topology",
+                "placement",
+                "ownership_context",
+                "telemetry",
+            ],
+        )
+
+
+class AuthorityTierTests(unittest.TestCase):
+    def test_authority_tier_values_match_rfc(self) -> None:
+        self.assertEqual(
+            enum_values(AuthorityTier),
+            ["authoritative", "preferred", "supplemental", "observe_only"],
+        )
+
+
+class AuthorityModeTests(unittest.TestCase):
+    def test_authority_mode_values_match_rfc(self) -> None:
+        self.assertEqual(
+            enum_values(AuthorityMode),
+            ["replace", "fill_if_missing", "merge", "observe_only"],
+        )
+
+
+class ExportTests(unittest.TestCase):
+    def test_enum_members_are_string_like(self) -> None:
+        self.assertEqual(NodeScope.PHYSICAL_DEVICE, "physical_device")
+        self.assertEqual(EdgeType.CONNECTED_TO, "connected_to")
+        self.assertEqual(Category.HARDWARE_INVENTORY, "hardware_inventory")
+        self.assertEqual(AuthorityTier.AUTHORITATIVE, "authoritative")
+        self.assertEqual(AuthorityMode.FILL_IF_MISSING, "fill_if_missing")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add the first `src/canonical_discovery/core` package skeleton
- implement RFC-backed `StrEnum` definitions for node scopes, edge types, categories, authority tiers, and authority modes
- add tests that lock the enum values to the authoritative RFC lists

## Validation
- `docker build --target runtime -t canonical-discovery:verify-2 .`
- `docker run --rm canonical-discovery:verify-2 sh -lc "export PATH=/opt/poetry/bin:$PATH && poetry install --with dev && poetry run ruff format --check . && poetry run ruff check . && PYTHONPATH=src poetry run pytest"`

Closes #2