### PR TITLE
docs: require per-finding PR review comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,8 @@
 - Build unit tests alongside code changes; do not treat tests as a later cleanup pass.
 - Run the relevant `lint -> test -> build` verification steps before committing when feasible.
 - For Python changes, treat Ruff verification as both `ruff format --check` and `ruff check`; repair files locally before commit if either fails.
+- Publish review findings or no-findings results back to the PR thread when a review is requested.
+- When there are findings, publish one PR comment per finding and include relevant code locations, using GitHub code references when possible.
 - Do not merge until CI, review gates, and runtime evidence checks are satisfied.
 - When runtime behavior changes, validate using API-retrieved artifacts and status rather than direct database inspection.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,12 @@ rather than serving as the default base for issue branches.
 
 PRs should prefer small, coherent commits over large batch drops.
 
+Review outcomes should be published back to the PR thread so findings, no-findings
+results, and residual risks are visible to humans and other agents.
+
+When a review identifies issues, publish one PR comment per finding and include
+relevant code locations. Use GitHub code references when possible.
+
 ## Merge Gates
 
 Merge should not occur until all of the following are true:


### PR DESCRIPTION
## Summary
- require one PR comment per review finding
- require relevant code locations in findings
- prefer GitHub code references when possible

## Validation
- documentation-only change

Closes #39