### PR TITLE
feat: add canonical core dataclasses

### DIFF
--- a/src/canonical_discovery/core/__init__.py
+++ b/src/canonical_discovery/core/__init__.py
@@ -7,11 +7,16 @@ from canonical_discovery.core.enums import (
     EdgeType,
     NodeScope,
 )
+from canonical_discovery.core.models import Claim, Edge, GraphArtifact, Node
 
 __all__ = [
     "AuthorityMode",
     "AuthorityTier",
     "Category",
+    "Claim",
+    "Edge",
     "EdgeType",
+    "GraphArtifact",
+    "Node",
     "NodeScope",
 ]

--- a/src/canonical_discovery/core/__init__.py
+++ b/src/canonical_discovery/core/__init__.py
@@ -7,7 +7,7 @@ from canonical_discovery.core.enums import (
     EdgeType,
     NodeScope,
 )
-from canonical_discovery.core.models import Claim, Edge, GraphArtifact, Node
+from canonical_discovery.core.models import Claim, Edge, EdgeClaim, GraphArtifact, Node, NodeClaim
 
 __all__ = [
     "AuthorityMode",
@@ -15,8 +15,10 @@ __all__ = [
     "Category",
     "Claim",
     "Edge",
+    "EdgeClaim",
     "EdgeType",
     "GraphArtifact",
     "Node",
+    "NodeClaim",
     "NodeScope",
 ]

--- a/src/canonical_discovery/core/models.py
+++ b/src/canonical_discovery/core/models.py
@@ -1,0 +1,59 @@
+"""Core dataclass models for canonical graph artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from canonical_discovery.core.enums import (
+    AuthorityMode,
+    AuthorityTier,
+    Category,
+    EdgeType,
+    NodeScope,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class Node:
+    """Canonical graph node."""
+
+    key: str
+    scope: NodeScope
+
+
+@dataclass(frozen=True, slots=True)
+class Edge:
+    """Canonical graph edge."""
+
+    key: str
+    edge_type: EdgeType
+    source_key: str
+    target_key: str
+
+
+@dataclass(frozen=True, slots=True)
+class Claim:
+    """Source-contributed assertion about a canonical object field."""
+
+    object_key: str
+    scope: NodeScope
+    category: Category
+    field_name: str
+    value: Any
+    source_name: str
+    provenance: dict[str, Any] = field(default_factory=dict)
+    timestamp: datetime | None = None
+    authority_tier: AuthorityTier = AuthorityTier.SUPPLEMENTAL
+    confidence: float = 0.0
+    mode: AuthorityMode = AuthorityMode.REPLACE
+
+
+@dataclass(frozen=True, slots=True)
+class GraphArtifact:
+    """Canonical graph artifact emitted by adapters or carried through ingest."""
+
+    nodes: tuple[Node, ...] = ()
+    edges: tuple[Edge, ...] = ()
+    claims: tuple[Claim, ...] = ()

--- a/src/canonical_discovery/core/models.py
+++ b/src/canonical_discovery/core/models.py
@@ -34,10 +34,10 @@ class Edge:
 
 
 @dataclass(frozen=True, slots=True)
-class Claim:
-    """Source-contributed assertion about a canonical object field."""
+class NodeClaim:
+    """Source-contributed assertion about a canonical node field."""
 
-    object_key: str
+    node_key: str
     scope: NodeScope
     category: Category
     field_name: str
@@ -48,6 +48,26 @@ class Claim:
     authority_tier: AuthorityTier = AuthorityTier.SUPPLEMENTAL
     confidence: float = 0.0
     mode: AuthorityMode = AuthorityMode.REPLACE
+
+
+@dataclass(frozen=True, slots=True)
+class EdgeClaim:
+    """Source-contributed assertion about a canonical edge field."""
+
+    edge_key: str
+    edge_type: EdgeType
+    category: Category
+    field_name: str
+    value: Any
+    source_name: str
+    provenance: dict[str, Any] = field(default_factory=dict)
+    timestamp: datetime | None = None
+    authority_tier: AuthorityTier = AuthorityTier.SUPPLEMENTAL
+    confidence: float = 0.0
+    mode: AuthorityMode = AuthorityMode.REPLACE
+
+
+type Claim = NodeClaim | EdgeClaim
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_core_models.py
+++ b/tests/test_core_models.py
@@ -9,11 +9,12 @@ from canonical_discovery.core import (
     AuthorityMode,
     AuthorityTier,
     Category,
-    Claim,
     Edge,
+    EdgeClaim,
     EdgeType,
     GraphArtifact,
     Node,
+    NodeClaim,
     NodeScope,
 )
 
@@ -41,10 +42,10 @@ class EdgeTests(unittest.TestCase):
         self.assertEqual(edge.target_key, "port-b")
 
 
-class ClaimTests(unittest.TestCase):
-    def test_claim_defaults_match_minimal_contract(self) -> None:
-        claim = Claim(
-            object_key="device-1",
+class NodeClaimTests(unittest.TestCase):
+    def test_node_claim_defaults_match_minimal_contract(self) -> None:
+        claim = NodeClaim(
+            node_key="device-1",
             scope=NodeScope.PHYSICAL_DEVICE,
             category=Category.IDENTITY,
             field_name="hostname",
@@ -52,7 +53,7 @@ class ClaimTests(unittest.TestCase):
             source_name="example-source",
         )
 
-        self.assertEqual(claim.object_key, "device-1")
+        self.assertEqual(claim.node_key, "device-1")
         self.assertEqual(claim.scope, NodeScope.PHYSICAL_DEVICE)
         self.assertEqual(claim.category, Category.IDENTITY)
         self.assertEqual(claim.field_name, "hostname")
@@ -64,10 +65,10 @@ class ClaimTests(unittest.TestCase):
         self.assertEqual(claim.confidence, 0.0)
         self.assertEqual(claim.mode, AuthorityMode.REPLACE)
 
-    def test_claim_accepts_explicit_provenance_and_resolution_fields(self) -> None:
+    def test_node_claim_accepts_explicit_provenance_and_resolution_fields(self) -> None:
         timestamp = datetime(2026, 4, 30, 12, 0, 0)
-        claim = Claim(
-            object_key="device-1",
+        claim = NodeClaim(
+            node_key="device-1",
             scope=NodeScope.PHYSICAL_DEVICE,
             category=Category.HARDWARE_INVENTORY,
             field_name="serial",
@@ -87,6 +88,30 @@ class ClaimTests(unittest.TestCase):
         self.assertEqual(claim.mode, AuthorityMode.FILL_IF_MISSING)
 
 
+class EdgeClaimTests(unittest.TestCase):
+    def test_edge_claim_defaults_match_minimal_contract(self) -> None:
+        claim = EdgeClaim(
+            edge_key="edge-1",
+            edge_type=EdgeType.CONNECTED_TO,
+            category=Category.TOPOLOGY,
+            field_name="state",
+            value="up",
+            source_name="example-source",
+        )
+
+        self.assertEqual(claim.edge_key, "edge-1")
+        self.assertEqual(claim.edge_type, EdgeType.CONNECTED_TO)
+        self.assertEqual(claim.category, Category.TOPOLOGY)
+        self.assertEqual(claim.field_name, "state")
+        self.assertEqual(claim.value, "up")
+        self.assertEqual(claim.source_name, "example-source")
+        self.assertEqual(claim.provenance, {})
+        self.assertIsNone(claim.timestamp)
+        self.assertEqual(claim.authority_tier, AuthorityTier.SUPPLEMENTAL)
+        self.assertEqual(claim.confidence, 0.0)
+        self.assertEqual(claim.mode, AuthorityMode.REPLACE)
+
+
 class GraphArtifactTests(unittest.TestCase):
     def test_graph_artifact_groups_nodes_edges_and_claims(self) -> None:
         node = Node(key="device-1", scope=NodeScope.PHYSICAL_DEVICE)
@@ -96,8 +121,8 @@ class GraphArtifactTests(unittest.TestCase):
             source_key="device-1",
             target_key="component-1",
         )
-        claim = Claim(
-            object_key="device-1",
+        claim = NodeClaim(
+            node_key="device-1",
             scope=NodeScope.PHYSICAL_DEVICE,
             category=Category.IDENTITY,
             field_name="hostname",

--- a/tests/test_core_models.py
+++ b/tests/test_core_models.py
@@ -1,0 +1,123 @@
+"""Tests for core dataclass models."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime
+
+from canonical_discovery.core import (
+    AuthorityMode,
+    AuthorityTier,
+    Category,
+    Claim,
+    Edge,
+    EdgeType,
+    GraphArtifact,
+    Node,
+    NodeScope,
+)
+
+
+class NodeTests(unittest.TestCase):
+    def test_node_captures_key_and_scope(self) -> None:
+        node = Node(key="device-1", scope=NodeScope.PHYSICAL_DEVICE)
+
+        self.assertEqual(node.key, "device-1")
+        self.assertEqual(node.scope, NodeScope.PHYSICAL_DEVICE)
+
+
+class EdgeTests(unittest.TestCase):
+    def test_edge_captures_type_and_endpoints(self) -> None:
+        edge = Edge(
+            key="edge-1",
+            edge_type=EdgeType.CONNECTED_TO,
+            source_key="port-a",
+            target_key="port-b",
+        )
+
+        self.assertEqual(edge.key, "edge-1")
+        self.assertEqual(edge.edge_type, EdgeType.CONNECTED_TO)
+        self.assertEqual(edge.source_key, "port-a")
+        self.assertEqual(edge.target_key, "port-b")
+
+
+class ClaimTests(unittest.TestCase):
+    def test_claim_defaults_match_minimal_contract(self) -> None:
+        claim = Claim(
+            object_key="device-1",
+            scope=NodeScope.PHYSICAL_DEVICE,
+            category=Category.IDENTITY,
+            field_name="hostname",
+            value="router-1",
+            source_name="example-source",
+        )
+
+        self.assertEqual(claim.object_key, "device-1")
+        self.assertEqual(claim.scope, NodeScope.PHYSICAL_DEVICE)
+        self.assertEqual(claim.category, Category.IDENTITY)
+        self.assertEqual(claim.field_name, "hostname")
+        self.assertEqual(claim.value, "router-1")
+        self.assertEqual(claim.source_name, "example-source")
+        self.assertEqual(claim.provenance, {})
+        self.assertIsNone(claim.timestamp)
+        self.assertEqual(claim.authority_tier, AuthorityTier.SUPPLEMENTAL)
+        self.assertEqual(claim.confidence, 0.0)
+        self.assertEqual(claim.mode, AuthorityMode.REPLACE)
+
+    def test_claim_accepts_explicit_provenance_and_resolution_fields(self) -> None:
+        timestamp = datetime(2026, 4, 30, 12, 0, 0)
+        claim = Claim(
+            object_key="device-1",
+            scope=NodeScope.PHYSICAL_DEVICE,
+            category=Category.HARDWARE_INVENTORY,
+            field_name="serial",
+            value="ABC123",
+            source_name="inventory-source",
+            provenance={"record_id": "42"},
+            timestamp=timestamp,
+            authority_tier=AuthorityTier.AUTHORITATIVE,
+            confidence=1.0,
+            mode=AuthorityMode.FILL_IF_MISSING,
+        )
+
+        self.assertEqual(claim.provenance, {"record_id": "42"})
+        self.assertEqual(claim.timestamp, timestamp)
+        self.assertEqual(claim.authority_tier, AuthorityTier.AUTHORITATIVE)
+        self.assertEqual(claim.confidence, 1.0)
+        self.assertEqual(claim.mode, AuthorityMode.FILL_IF_MISSING)
+
+
+class GraphArtifactTests(unittest.TestCase):
+    def test_graph_artifact_groups_nodes_edges_and_claims(self) -> None:
+        node = Node(key="device-1", scope=NodeScope.PHYSICAL_DEVICE)
+        edge = Edge(
+            key="edge-1",
+            edge_type=EdgeType.CONTAINS,
+            source_key="device-1",
+            target_key="component-1",
+        )
+        claim = Claim(
+            object_key="device-1",
+            scope=NodeScope.PHYSICAL_DEVICE,
+            category=Category.IDENTITY,
+            field_name="hostname",
+            value="router-1",
+            source_name="example-source",
+        )
+
+        artifact = GraphArtifact(nodes=(node,), edges=(edge,), claims=(claim,))
+
+        self.assertEqual(artifact.nodes, (node,))
+        self.assertEqual(artifact.edges, (edge,))
+        self.assertEqual(artifact.claims, (claim,))
+
+    def test_graph_artifact_defaults_to_empty_tuples(self) -> None:
+        artifact = GraphArtifact()
+
+        self.assertEqual(artifact.nodes, ())
+        self.assertEqual(artifact.edges, ())
+        self.assertEqual(artifact.claims, ())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add the first `Node`, `Edge`, `Claim`, and `GraphArtifact` dataclasses in `canonical_discovery.core.models`
- re-export the new models from `canonical_discovery.core`
- add RFC-aligned tests covering defaults, explicit claim metadata, and graph artifact grouping

## Validation
- `docker build --target runtime -t canonical-discovery:verify-3 .`
- `docker run --rm canonical-discovery:verify-3 sh -lc "export PATH=/opt/poetry/bin:$PATH && poetry install --with dev && poetry run ruff format --check . && poetry run ruff check . && PYTHONPATH=src poetry run pytest"`

Closes #3