### PR TITLE
feat: add graph invariant validation

### DIFF
--- a/src/canonical_discovery/core/__init__.py
+++ b/src/canonical_discovery/core/__init__.py
@@ -8,6 +8,7 @@ from canonical_discovery.core.enums import (
     NodeScope,
 )
 from canonical_discovery.core.models import Claim, Edge, EdgeClaim, GraphArtifact, Node, NodeClaim
+from canonical_discovery.core.validation import validate_graph_invariants
 
 __all__ = [
     "AuthorityMode",
@@ -21,4 +22,5 @@ __all__ = [
     "Node",
     "NodeClaim",
     "NodeScope",
+    "validate_graph_invariants",
 ]

--- a/src/canonical_discovery/core/validation.py
+++ b/src/canonical_discovery/core/validation.py
@@ -13,6 +13,10 @@ def validate_graph_invariants(graph: GraphArtifact) -> list[str]:
     errors: list[str] = []
     hosting_edges_by_target = {}
     connected_to_edges_by_link = {}
+    seen_device_component_attachments = set()
+    valid_device_component_attachments = set()
+    seen_ip_address_attachments = set()
+    valid_ip_address_attachments = set()
 
     for edge in graph.edges:
         if edge.source_key not in node_scope_by_key:
@@ -42,10 +46,14 @@ def validate_graph_invariants(graph: GraphArtifact) -> list[str]:
             NodeScope.PHYSICAL_DEVICE,
             NodeScope.DEVICE_COMPONENT,
         }:
+            seen_device_component_attachments.add(edge.target_key)
             errors.append(
                 f"device_component '{edge.target_key}' must attach to a physical_device or "
                 f"device_component, not '{source_scope.value}'"
             )
+        elif target_scope is NodeScope.DEVICE_COMPONENT:
+            seen_device_component_attachments.add(edge.target_key)
+            valid_device_component_attachments.add(edge.target_key)
 
         if (
             edge.edge_type is EdgeType.CONNECTED_TO
@@ -58,10 +66,14 @@ def validate_graph_invariants(graph: GraphArtifact) -> list[str]:
             )
 
         if target_scope is NodeScope.IP_ADDRESS and edge.edge_type is not EdgeType.ASSIGNED_TO:
+            seen_ip_address_attachments.add(edge.target_key)
             errors.append(
                 f"ip_address '{edge.target_key}' must be attached with assigned_to, not "
                 f"'{edge.edge_type.value}'"
             )
+        elif target_scope is NodeScope.IP_ADDRESS:
+            seen_ip_address_attachments.add(edge.target_key)
+            valid_ip_address_attachments.add(edge.target_key)
 
     for node_key, scope in node_scope_by_key.items():
         if scope is NodeScope.OS_INSTANCE:
@@ -83,5 +95,22 @@ def validate_graph_invariants(graph: GraphArtifact) -> list[str]:
 
             if any(target_scope is not NodeScope.PORT for _, target_scope in connected_edges):
                 errors.append(f"link '{node_key}' must connect only port endpoints")
+
+        if (
+            scope is NodeScope.DEVICE_COMPONENT
+            and node_key not in seen_device_component_attachments
+            and node_key not in valid_device_component_attachments
+        ):
+            errors.append(
+                f"device_component '{node_key}' must attach to a physical_device or "
+                f"device_component"
+            )
+
+        if (
+            scope is NodeScope.IP_ADDRESS
+            and node_key not in seen_ip_address_attachments
+            and node_key not in valid_ip_address_attachments
+        ):
+            errors.append(f"ip_address '{node_key}' must have an explicit assigned_to relationship")
 
     return errors

--- a/src/canonical_discovery/core/validation.py
+++ b/src/canonical_discovery/core/validation.py
@@ -1,0 +1,67 @@
+"""Graph invariant validation helpers for canonical graph artifacts."""
+
+from __future__ import annotations
+
+from canonical_discovery.core.enums import EdgeType, NodeScope
+from canonical_discovery.core.models import GraphArtifact
+
+
+def validate_graph_invariants(graph: GraphArtifact) -> list[str]:
+    """Return invariant violations for the provided canonical graph."""
+
+    node_scope_by_key = {node.key: node.scope for node in graph.nodes}
+    errors: list[str] = []
+    hosting_edges_by_target = {}
+
+    for edge in graph.edges:
+        if edge.source_key not in node_scope_by_key:
+            errors.append(f"edge '{edge.key}' references unknown source '{edge.source_key}'")
+            continue
+        if edge.target_key not in node_scope_by_key:
+            errors.append(f"edge '{edge.key}' references unknown target '{edge.target_key}'")
+            continue
+
+        source_scope = node_scope_by_key[edge.source_key]
+        target_scope = node_scope_by_key[edge.target_key]
+
+        if source_scope is NodeScope.LINK:
+            errors.append(
+                f"link node '{edge.source_key}' cannot be the source of edge '{edge.key}'"
+            )
+
+        if edge.edge_type is EdgeType.HOSTS and target_scope is NodeScope.OS_INSTANCE:
+            hosting_edges_by_target.setdefault(edge.target_key, []).append(edge.key)
+
+        if target_scope is NodeScope.DEVICE_COMPONENT and source_scope not in {
+            NodeScope.PHYSICAL_DEVICE,
+            NodeScope.DEVICE_COMPONENT,
+        }:
+            errors.append(
+                f"device_component '{edge.target_key}' must attach to a physical_device or "
+                f"device_component, not '{source_scope.value}'"
+            )
+
+        if edge.edge_type is EdgeType.CONNECTED_TO and (
+            source_scope is not NodeScope.PORT or target_scope is not NodeScope.PORT
+        ):
+            errors.append(
+                f"connected_to edge '{edge.key}' must connect port nodes, not "
+                f"'{source_scope.value}' -> '{target_scope.value}'"
+            )
+
+        if target_scope is NodeScope.IP_ADDRESS and edge.edge_type is not EdgeType.ASSIGNED_TO:
+            errors.append(
+                f"ip_address '{edge.target_key}' must be attached with assigned_to, not "
+                f"'{edge.edge_type.value}'"
+            )
+
+    for node_key, scope in node_scope_by_key.items():
+        if scope is NodeScope.OS_INSTANCE:
+            hosting_edges = hosting_edges_by_target.get(node_key, [])
+            if len(hosting_edges) != 1:
+                errors.append(
+                    f"os_instance '{node_key}' must have exactly one hosts edge, found "
+                    f"{len(hosting_edges)}"
+                )
+
+    return errors

--- a/src/canonical_discovery/core/validation.py
+++ b/src/canonical_discovery/core/validation.py
@@ -12,6 +12,7 @@ def validate_graph_invariants(graph: GraphArtifact) -> list[str]:
     node_scope_by_key = {node.key: node.scope for node in graph.nodes}
     errors: list[str] = []
     hosting_edges_by_target = {}
+    connected_to_edges_by_link = {}
 
     for edge in graph.edges:
         if edge.source_key not in node_scope_by_key:
@@ -24,13 +25,18 @@ def validate_graph_invariants(graph: GraphArtifact) -> list[str]:
         source_scope = node_scope_by_key[edge.source_key]
         target_scope = node_scope_by_key[edge.target_key]
 
-        if source_scope is NodeScope.LINK:
-            errors.append(
-                f"link node '{edge.source_key}' cannot be the source of edge '{edge.key}'"
-            )
-
         if edge.edge_type is EdgeType.HOSTS and target_scope is NodeScope.OS_INSTANCE:
+            if source_scope not in {NodeScope.PHYSICAL_DEVICE, NodeScope.VIRTUAL_MACHINE}:
+                errors.append(
+                    f"os_instance '{edge.target_key}' must be hosted by a compute object, not "
+                    f"'{source_scope.value}'"
+                )
             hosting_edges_by_target.setdefault(edge.target_key, []).append(edge.key)
+
+        if edge.edge_type is EdgeType.CONNECTED_TO and source_scope is NodeScope.LINK:
+            connected_to_edges_by_link.setdefault(edge.source_key, []).append(
+                (edge.key, target_scope)
+            )
 
         if target_scope is NodeScope.DEVICE_COMPONENT and source_scope not in {
             NodeScope.PHYSICAL_DEVICE,
@@ -41,8 +47,10 @@ def validate_graph_invariants(graph: GraphArtifact) -> list[str]:
                 f"device_component, not '{source_scope.value}'"
             )
 
-        if edge.edge_type is EdgeType.CONNECTED_TO and (
-            source_scope is not NodeScope.PORT or target_scope is not NodeScope.PORT
+        if (
+            edge.edge_type is EdgeType.CONNECTED_TO
+            and source_scope is not NodeScope.LINK
+            and (source_scope is not NodeScope.PORT or target_scope is not NodeScope.PORT)
         ):
             errors.append(
                 f"connected_to edge '{edge.key}' must connect port nodes, not "
@@ -63,5 +71,17 @@ def validate_graph_invariants(graph: GraphArtifact) -> list[str]:
                     f"os_instance '{node_key}' must have exactly one hosts edge, found "
                     f"{len(hosting_edges)}"
                 )
+
+        if scope is NodeScope.LINK:
+            connected_edges = connected_to_edges_by_link.get(node_key, [])
+            if len(connected_edges) != 2:
+                errors.append(
+                    f"link '{node_key}' must connect exactly two port endpoints, found "
+                    f"{len(connected_edges)}"
+                )
+                continue
+
+            if any(target_scope is not NodeScope.PORT for _, target_scope in connected_edges):
+                errors.append(f"link '{node_key}' must connect only port endpoints")
 
     return errors

--- a/tests/test_core_validation.py
+++ b/tests/test_core_validation.py
@@ -20,6 +20,7 @@ class GraphInvariantValidationTests(unittest.TestCase):
             nodes=(
                 Node(key="device-1", scope=NodeScope.PHYSICAL_DEVICE),
                 Node(key="component-1", scope=NodeScope.DEVICE_COMPONENT),
+                Node(key="link-1", scope=NodeScope.LINK),
                 Node(key="port-a", scope=NodeScope.PORT),
                 Node(key="port-b", scope=NodeScope.PORT),
                 Node(key="os-1", scope=NodeScope.OS_INSTANCE),
@@ -35,7 +36,13 @@ class GraphInvariantValidationTests(unittest.TestCase):
                 Edge(
                     key="edge-link",
                     edge_type=EdgeType.CONNECTED_TO,
-                    source_key="port-a",
+                    source_key="link-1",
+                    target_key="port-a",
+                ),
+                Edge(
+                    key="edge-link-peer",
+                    edge_type=EdgeType.CONNECTED_TO,
+                    source_key="link-1",
                     target_key="port-b",
                 ),
                 Edge(
@@ -81,6 +88,27 @@ class GraphInvariantValidationTests(unittest.TestCase):
         self.assertEqual(
             validate_graph_invariants(graph),
             ["os_instance 'os-1' must have exactly one hosts edge, found 2"],
+        )
+
+    def test_os_instance_host_must_be_compute_scope(self) -> None:
+        graph = GraphArtifact(
+            nodes=(
+                Node(key="port-1", scope=NodeScope.PORT),
+                Node(key="os-1", scope=NodeScope.OS_INSTANCE),
+            ),
+            edges=(
+                Edge(
+                    key="edge-hosts",
+                    edge_type=EdgeType.HOSTS,
+                    source_key="port-1",
+                    target_key="os-1",
+                ),
+            ),
+        )
+
+        self.assertEqual(
+            validate_graph_invariants(graph),
+            ["os_instance 'os-1' must be hosted by a compute object, not 'port'"],
         )
 
     def test_connected_to_requires_port_nodes(self) -> None:
@@ -168,6 +196,55 @@ class GraphInvariantValidationTests(unittest.TestCase):
         self.assertEqual(
             validate_graph_invariants(graph),
             ["edge 'edge-missing' references unknown target 'port-2'"],
+        )
+
+    def test_link_requires_exactly_two_port_endpoints(self) -> None:
+        graph = GraphArtifact(
+            nodes=(
+                Node(key="link-1", scope=NodeScope.LINK),
+                Node(key="port-1", scope=NodeScope.PORT),
+            ),
+            edges=(
+                Edge(
+                    key="edge-link",
+                    edge_type=EdgeType.CONNECTED_TO,
+                    source_key="link-1",
+                    target_key="port-1",
+                ),
+            ),
+        )
+
+        self.assertEqual(
+            validate_graph_invariants(graph),
+            ["link 'link-1' must connect exactly two port endpoints, found 1"],
+        )
+
+    def test_link_requires_port_targets_only(self) -> None:
+        graph = GraphArtifact(
+            nodes=(
+                Node(key="link-1", scope=NodeScope.LINK),
+                Node(key="port-1", scope=NodeScope.PORT),
+                Node(key="device-1", scope=NodeScope.PHYSICAL_DEVICE),
+            ),
+            edges=(
+                Edge(
+                    key="edge-link-1",
+                    edge_type=EdgeType.CONNECTED_TO,
+                    source_key="link-1",
+                    target_key="port-1",
+                ),
+                Edge(
+                    key="edge-link-2",
+                    edge_type=EdgeType.CONNECTED_TO,
+                    source_key="link-1",
+                    target_key="device-1",
+                ),
+            ),
+        )
+
+        self.assertEqual(
+            validate_graph_invariants(graph),
+            ["link 'link-1' must connect only port endpoints"],
         )
 
 

--- a/tests/test_core_validation.py
+++ b/tests/test_core_validation.py
@@ -1,0 +1,175 @@
+"""Tests for canonical graph invariant validation."""
+
+from __future__ import annotations
+
+import unittest
+
+from canonical_discovery.core import (
+    Edge,
+    EdgeType,
+    GraphArtifact,
+    Node,
+    NodeScope,
+    validate_graph_invariants,
+)
+
+
+class GraphInvariantValidationTests(unittest.TestCase):
+    def test_valid_graph_has_no_invariant_errors(self) -> None:
+        graph = GraphArtifact(
+            nodes=(
+                Node(key="device-1", scope=NodeScope.PHYSICAL_DEVICE),
+                Node(key="component-1", scope=NodeScope.DEVICE_COMPONENT),
+                Node(key="port-a", scope=NodeScope.PORT),
+                Node(key="port-b", scope=NodeScope.PORT),
+                Node(key="os-1", scope=NodeScope.OS_INSTANCE),
+                Node(key="ip-1", scope=NodeScope.IP_ADDRESS),
+            ),
+            edges=(
+                Edge(
+                    key="edge-component",
+                    edge_type=EdgeType.CONTAINS,
+                    source_key="device-1",
+                    target_key="component-1",
+                ),
+                Edge(
+                    key="edge-link",
+                    edge_type=EdgeType.CONNECTED_TO,
+                    source_key="port-a",
+                    target_key="port-b",
+                ),
+                Edge(
+                    key="edge-hosts",
+                    edge_type=EdgeType.HOSTS,
+                    source_key="device-1",
+                    target_key="os-1",
+                ),
+                Edge(
+                    key="edge-ip",
+                    edge_type=EdgeType.ASSIGNED_TO,
+                    source_key="port-a",
+                    target_key="ip-1",
+                ),
+            ),
+        )
+
+        self.assertEqual(validate_graph_invariants(graph), [])
+
+    def test_os_instance_requires_exactly_one_hosting_edge(self) -> None:
+        graph = GraphArtifact(
+            nodes=(
+                Node(key="device-1", scope=NodeScope.PHYSICAL_DEVICE),
+                Node(key="device-2", scope=NodeScope.PHYSICAL_DEVICE),
+                Node(key="os-1", scope=NodeScope.OS_INSTANCE),
+            ),
+            edges=(
+                Edge(
+                    key="edge-hosts-1",
+                    edge_type=EdgeType.HOSTS,
+                    source_key="device-1",
+                    target_key="os-1",
+                ),
+                Edge(
+                    key="edge-hosts-2",
+                    edge_type=EdgeType.HOSTS,
+                    source_key="device-2",
+                    target_key="os-1",
+                ),
+            ),
+        )
+
+        self.assertEqual(
+            validate_graph_invariants(graph),
+            ["os_instance 'os-1' must have exactly one hosts edge, found 2"],
+        )
+
+    def test_connected_to_requires_port_nodes(self) -> None:
+        graph = GraphArtifact(
+            nodes=(
+                Node(key="device-1", scope=NodeScope.PHYSICAL_DEVICE),
+                Node(key="port-1", scope=NodeScope.PORT),
+            ),
+            edges=(
+                Edge(
+                    key="edge-link",
+                    edge_type=EdgeType.CONNECTED_TO,
+                    source_key="device-1",
+                    target_key="port-1",
+                ),
+            ),
+        )
+
+        self.assertEqual(
+            validate_graph_invariants(graph),
+            [
+                "connected_to edge 'edge-link' must connect port nodes, not "
+                "'physical_device' -> 'port'"
+            ],
+        )
+
+    def test_device_component_requires_supported_parent_scope(self) -> None:
+        graph = GraphArtifact(
+            nodes=(
+                Node(key="vm-1", scope=NodeScope.VIRTUAL_MACHINE),
+                Node(key="component-1", scope=NodeScope.DEVICE_COMPONENT),
+            ),
+            edges=(
+                Edge(
+                    key="edge-component",
+                    edge_type=EdgeType.CONTAINS,
+                    source_key="vm-1",
+                    target_key="component-1",
+                ),
+            ),
+        )
+
+        self.assertEqual(
+            validate_graph_invariants(graph),
+            [
+                "device_component 'component-1' must attach to a physical_device or "
+                "device_component, not 'virtual_machine'"
+            ],
+        )
+
+    def test_ip_address_requires_assigned_to_relationship(self) -> None:
+        graph = GraphArtifact(
+            nodes=(
+                Node(key="port-1", scope=NodeScope.PORT),
+                Node(key="ip-1", scope=NodeScope.IP_ADDRESS),
+            ),
+            edges=(
+                Edge(
+                    key="edge-ip",
+                    edge_type=EdgeType.CONTAINS,
+                    source_key="port-1",
+                    target_key="ip-1",
+                ),
+            ),
+        )
+
+        self.assertEqual(
+            validate_graph_invariants(graph),
+            ["ip_address 'ip-1' must be attached with assigned_to, not 'contains'"],
+        )
+
+    def test_unknown_edge_endpoint_is_reported(self) -> None:
+        graph = GraphArtifact(
+            nodes=(Node(key="port-1", scope=NodeScope.PORT),),
+            edges=(
+                Edge(
+                    key="edge-missing",
+                    edge_type=EdgeType.CONNECTED_TO,
+                    source_key="port-1",
+                    target_key="port-2",
+                ),
+            ),
+        )
+
+        self.assertEqual(
+            validate_graph_invariants(graph),
+            ["edge 'edge-missing' references unknown target 'port-2'"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_core_validation.py
+++ b/tests/test_core_validation.py
@@ -159,6 +159,16 @@ class GraphInvariantValidationTests(unittest.TestCase):
             ],
         )
 
+    def test_device_component_requires_attachment_edge(self) -> None:
+        graph = GraphArtifact(
+            nodes=(Node(key="component-1", scope=NodeScope.DEVICE_COMPONENT),),
+        )
+
+        self.assertEqual(
+            validate_graph_invariants(graph),
+            ["device_component 'component-1' must attach to a physical_device or device_component"],
+        )
+
     def test_ip_address_requires_assigned_to_relationship(self) -> None:
         graph = GraphArtifact(
             nodes=(
@@ -178,6 +188,16 @@ class GraphInvariantValidationTests(unittest.TestCase):
         self.assertEqual(
             validate_graph_invariants(graph),
             ["ip_address 'ip-1' must be attached with assigned_to, not 'contains'"],
+        )
+
+    def test_ip_address_requires_explicit_attachment_edge(self) -> None:
+        graph = GraphArtifact(
+            nodes=(Node(key="ip-1", scope=NodeScope.IP_ADDRESS),),
+        )
+
+        self.assertEqual(
+            validate_graph_invariants(graph),
+            ["ip_address 'ip-1' must have an explicit assigned_to relationship"],
         )
 
     def test_unknown_edge_endpoint_is_reported(self) -> None:


### PR DESCRIPTION
## Summary
- add the first canonical graph invariant validator in `canonical_discovery.core.validation`
- export the validator from `canonical_discovery.core`
- add tests covering valid graphs plus the first invalid shapes from RFC 0001

## Validation
- `docker compose build app`
- `docker compose run --rm app sh -lc "export PATH=/opt/poetry/bin:$PATH && poetry install --with dev && poetry run ruff format --check . && poetry run ruff check . && PYTHONPATH=src poetry run pytest"`

Closes #4