### PR TITLE
docs: prefer docker compose for repo workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,12 +32,14 @@
 
 ## Verified Commands
 
+- Prefer `docker compose` over raw `docker` when using repo-defined services.
 - Build the devcontainer image with `docker compose build devcontainer`.
 - Install dev dependencies in the container with `docker compose run --rm devcontainer sh -lc "export PATH=/opt/poetry/bin:$PATH && poetry install --with dev"`.
 - Lint in the container with `docker compose run --rm devcontainer sh -lc "export PATH=/opt/poetry/bin:$PATH && poetry run ruff check ."`.
 - Format in the container with `docker compose run --rm devcontainer sh -lc "export PATH=/opt/poetry/bin:$PATH && poetry run ruff format ."`.
 - Run tests in the container with `docker compose run --rm devcontainer sh -lc "export PATH=/opt/poetry/bin:$PATH && PYTHONPATH=src poetry run pytest"`.
 - Build the runtime image with `docker compose build app`.
+- For branch-local copied-source verification, prefer `docker compose run --rm app sh -lc "export PATH=/opt/poetry/bin:$PATH && poetry install --with dev && poetry run ruff format --check . && poetry run ruff check . && PYTHONPATH=src poetry run pytest"`.
 - The devcontainer uses the root `docker-compose.yml` service named `devcontainer`.
 - The devcontainer runs `poetry install --with dev` on create.
 - Poetry virtualenvs are stored in the container volume mounted at `/opt/poetry-venvs`, not in the repo checkout.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,19 @@ runtime image with an environment-configurable tag, so branch validation can use
 images such as `:dev`, `:pr1234`, or release tags without rewriting the compose
 file.
 
+When repository services are already modeled in `docker-compose.yml`, prefer
+`docker compose` over ad hoc raw `docker` commands.
+
+Use the services intentionally:
+
+- `devcontainer` for the bind-mounted development environment
+- `app` for copied-source runtime image builds and branch-local verification
+
+For branch-local copied-source verification, prefer commands such as:
+
+- `docker compose build app`
+- `docker compose run --rm app sh -lc "export PATH=/opt/poetry/bin:$PATH && poetry install --with dev && poetry run ruff format --check . && poetry run ruff check . && PYTHONPATH=src poetry run pytest"`
+
 ## Testing Philosophy
 
 The first code milestones should prioritize:

--- a/docs/development/BRANCHING_WORKFLOW.md
+++ b/docs/development/BRANCHING_WORKFLOW.md
@@ -48,3 +48,13 @@ Branch and PR builds may also publish review-specific tags such as `:pr1234`.
 
 Use local rebuilds when needed, but prefer the published branch image when the
 goal is to validate what CI built for the current integrated branch state.
+
+When working with repository-defined service environments, prefer `docker
+compose` commands over raw `docker` commands.
+
+In practice:
+
+- use `docker compose run --rm devcontainer ...` for bind-mounted development
+  environment commands
+- use `docker compose build app` and `docker compose run --rm app ...` for
+  copied-source branch-local verification against the current checkout


### PR DESCRIPTION
## Summary
- document `docker compose` as the default command path for repo-defined services
- clarify when to use `devcontainer` versus `app`
- document the copied-source `app` service as the preferred branch-local verification path

## Validation
- documentation-only change

Closes #43