### PR TITLE
feat: define minimal HCL contracts

### DIFF
--- a/src/canonical_discovery/config/__init__.py
+++ b/src/canonical_discovery/config/__init__.py
@@ -1,0 +1,29 @@
+"""Configuration contracts for canonical-discovery."""
+
+from canonical_discovery.config.hcl_models import (
+    AuthorityBlock,
+    AuthorityCategory,
+    AuthorityField,
+    AuthorityRule,
+    AuthorityScope,
+    HclDocument,
+    PolicyBlock,
+    PolicyClassify,
+    ProjectionBlock,
+    ProjectionScope,
+    SourceBlock,
+)
+
+__all__ = [
+    "AuthorityBlock",
+    "AuthorityCategory",
+    "AuthorityField",
+    "AuthorityRule",
+    "AuthorityScope",
+    "HclDocument",
+    "PolicyBlock",
+    "PolicyClassify",
+    "ProjectionBlock",
+    "ProjectionScope",
+    "SourceBlock",
+]

--- a/src/canonical_discovery/config/hcl_models.py
+++ b/src/canonical_discovery/config/hcl_models.py
@@ -1,0 +1,79 @@
+"""Minimal HCL contract dataclasses."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from canonical_discovery.core import AuthorityMode, AuthorityTier, Category, NodeScope
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorityRule:
+    tier: AuthorityTier
+    confidence: int | float
+    mode: AuthorityMode
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorityField:
+    name: str
+    rule: AuthorityRule
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorityCategory:
+    category: Category
+    rule: AuthorityRule
+    fields: tuple[AuthorityField, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorityScope:
+    scope: NodeScope
+    categories: tuple[AuthorityCategory, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorityBlock:
+    scopes: tuple[AuthorityScope, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class SourceBlock:
+    name: str
+    api_type: str
+    authority: AuthorityBlock | None = None
+    options: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyClassify:
+    target: str
+    attributes: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyBlock:
+    name: str
+    classifications: tuple[PolicyClassify, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectionScope:
+    scope: NodeScope
+    resource: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectionBlock:
+    name: str
+    include_scopes: tuple[NodeScope, ...] = ()
+    scopes: tuple[ProjectionScope, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class HclDocument:
+    sources: tuple[SourceBlock, ...] = ()
+    policies: tuple[PolicyBlock, ...] = ()
+    projections: tuple[ProjectionBlock, ...] = ()

--- a/src/canonical_discovery/config/hcl_models.py
+++ b/src/canonical_discovery/config/hcl_models.py
@@ -11,8 +11,8 @@ from canonical_discovery.core import AuthorityMode, AuthorityTier, Category, Nod
 @dataclass(frozen=True, slots=True)
 class AuthorityRule:
     tier: AuthorityTier
-    confidence: int | float
     mode: AuthorityMode
+    confidence: int | float | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -25,13 +25,13 @@ class AuthorityField:
 class AuthorityCategory:
     category: Category
     rule: AuthorityRule
-    fields: tuple[AuthorityField, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
 class AuthorityScope:
     scope: NodeScope
     categories: tuple[AuthorityCategory, ...] = ()
+    fields: tuple[AuthorityField, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -49,7 +49,7 @@ class SourceBlock:
 
 @dataclass(frozen=True, slots=True)
 class PolicyClassify:
-    target: str
+    target: NodeScope
     attributes: dict[str, Any] = field(default_factory=dict)
 
 

--- a/tests/test_hcl_models.py
+++ b/tests/test_hcl_models.py
@@ -1,0 +1,156 @@
+"""Tests for the minimal HCL contract dataclasses."""
+
+from __future__ import annotations
+
+import unittest
+
+from canonical_discovery.config import (
+    AuthorityBlock,
+    AuthorityCategory,
+    AuthorityField,
+    AuthorityRule,
+    AuthorityScope,
+    HclDocument,
+    PolicyBlock,
+    PolicyClassify,
+    ProjectionBlock,
+    ProjectionScope,
+    SourceBlock,
+)
+from canonical_discovery.core import AuthorityMode, AuthorityTier, Category, NodeScope
+
+
+class AuthorityModelTests(unittest.TestCase):
+    def test_authority_models_capture_scope_category_and_field_rules(self) -> None:
+        serial_field = AuthorityField(
+            name="serial",
+            rule=AuthorityRule(
+                tier=AuthorityTier.OBSERVE_ONLY,
+                confidence=0,
+                mode=AuthorityMode.OBSERVE_ONLY,
+            ),
+        )
+        category = AuthorityCategory(
+            category=Category.HARDWARE_INVENTORY,
+            rule=AuthorityRule(
+                tier=AuthorityTier.SUPPLEMENTAL,
+                confidence=20,
+                mode=AuthorityMode.FILL_IF_MISSING,
+            ),
+            fields=(serial_field,),
+        )
+        scope = AuthorityScope(
+            scope=NodeScope.PHYSICAL_DEVICE,
+            categories=(category,),
+        )
+        authority = AuthorityBlock(scopes=(scope,))
+
+        self.assertEqual(authority.scopes, (scope,))
+        self.assertEqual(scope.categories, (category,))
+        self.assertEqual(category.fields, (serial_field,))
+
+
+class SourceBlockTests(unittest.TestCase):
+    def test_source_block_matches_minimal_source_authority_example(self) -> None:
+        source = SourceBlock(
+            name="xclarity",
+            api_type="xclarity",
+            authority=AuthorityBlock(
+                scopes=(
+                    AuthorityScope(
+                        scope=NodeScope.PHYSICAL_DEVICE,
+                        categories=(
+                            AuthorityCategory(
+                                category=Category.HARDWARE_INVENTORY,
+                                rule=AuthorityRule(
+                                    tier=AuthorityTier.AUTHORITATIVE,
+                                    confidence=100,
+                                    mode=AuthorityMode.REPLACE,
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        self.assertEqual(source.name, "xclarity")
+        self.assertEqual(source.api_type, "xclarity")
+        self.assertIsNotNone(source.authority)
+        self.assertEqual(source.options, {})
+
+
+class PolicyBlockTests(unittest.TestCase):
+    def test_policy_block_captures_classification_attributes(self) -> None:
+        policy = PolicyBlock(
+            name="campus-defaults",
+            classifications=(
+                PolicyClassify(
+                    target="location",
+                    attributes={"site_map": "regex/site_map"},
+                ),
+                PolicyClassify(
+                    target="physical_device",
+                    attributes={"owner_group_map": "map/platform_owner"},
+                ),
+            ),
+        )
+
+        self.assertEqual(policy.name, "campus-defaults")
+        self.assertEqual(len(policy.classifications), 2)
+        self.assertEqual(policy.classifications[0].attributes["site_map"], "regex/site_map")
+
+
+class ProjectionBlockTests(unittest.TestCase):
+    def test_projection_block_supports_include_scopes_and_scope_resources(self) -> None:
+        projection = ProjectionBlock(
+            name="netbox",
+            include_scopes=(
+                NodeScope.PHYSICAL_DEVICE,
+                NodeScope.PORT,
+                NodeScope.VIRTUAL_MACHINE,
+                NodeScope.IP_ADDRESS,
+            ),
+            scopes=(
+                ProjectionScope(
+                    scope=NodeScope.PHYSICAL_DEVICE,
+                    resource="dcim.devices",
+                ),
+                ProjectionScope(
+                    scope=NodeScope.PORT,
+                    resource="dcim.interfaces",
+                ),
+            ),
+        )
+
+        self.assertEqual(projection.name, "netbox")
+        self.assertEqual(projection.include_scopes[0], NodeScope.PHYSICAL_DEVICE)
+        self.assertEqual(projection.scopes[0].resource, "dcim.devices")
+
+
+class HclDocumentTests(unittest.TestCase):
+    def test_hcl_document_groups_sources_policies_and_projections(self) -> None:
+        source = SourceBlock(name="vmware", api_type="vmware")
+        policy = PolicyBlock(name="campus")
+        projection = ProjectionBlock(name="netbox")
+
+        document = HclDocument(
+            sources=(source,),
+            policies=(policy,),
+            projections=(projection,),
+        )
+
+        self.assertEqual(document.sources, (source,))
+        self.assertEqual(document.policies, (policy,))
+        self.assertEqual(document.projections, (projection,))
+
+    def test_hcl_document_defaults_to_empty_sections(self) -> None:
+        document = HclDocument()
+
+        self.assertEqual(document.sources, ())
+        self.assertEqual(document.policies, ())
+        self.assertEqual(document.projections, ())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hcl_models.py
+++ b/tests/test_hcl_models.py
@@ -37,17 +37,25 @@ class AuthorityModelTests(unittest.TestCase):
                 confidence=20,
                 mode=AuthorityMode.FILL_IF_MISSING,
             ),
-            fields=(serial_field,),
         )
         scope = AuthorityScope(
             scope=NodeScope.PHYSICAL_DEVICE,
             categories=(category,),
+            fields=(serial_field,),
         )
         authority = AuthorityBlock(scopes=(scope,))
 
         self.assertEqual(authority.scopes, (scope,))
         self.assertEqual(scope.categories, (category,))
-        self.assertEqual(category.fields, (serial_field,))
+        self.assertEqual(scope.fields, (serial_field,))
+
+    def test_authority_rule_confidence_is_optional(self) -> None:
+        rule = AuthorityRule(
+            tier=AuthorityTier.AUTHORITATIVE,
+            mode=AuthorityMode.REPLACE,
+        )
+
+        self.assertIsNone(rule.confidence)
 
 
 class SourceBlockTests(unittest.TestCase):
@@ -86,11 +94,11 @@ class PolicyBlockTests(unittest.TestCase):
             name="campus-defaults",
             classifications=(
                 PolicyClassify(
-                    target="location",
+                    target=NodeScope.LOCATION,
                     attributes={"site_map": "regex/site_map"},
                 ),
                 PolicyClassify(
-                    target="physical_device",
+                    target=NodeScope.PHYSICAL_DEVICE,
                     attributes={"owner_group_map": "map/platform_owner"},
                 ),
             ),
@@ -98,6 +106,7 @@ class PolicyBlockTests(unittest.TestCase):
 
         self.assertEqual(policy.name, "campus-defaults")
         self.assertEqual(len(policy.classifications), 2)
+        self.assertEqual(policy.classifications[0].target, NodeScope.LOCATION)
         self.assertEqual(policy.classifications[0].attributes["site_map"], "regex/site_map")
 
 


### PR DESCRIPTION
## Summary
- add the first minimal HCL contract dataclasses under `canonical_discovery.config`
- define typed structures for `source`, `authority`, `policy`, and `projection` blocks
- add tests covering the minimal RFC-backed HCL contract surface

## Validation
- `docker compose build app`
- `docker compose run --rm app sh -lc "export PATH=/opt/poetry/bin:$PATH && poetry install --with dev && poetry run ruff format --check . && poetry run ruff check . && PYTHONPATH=src poetry run pytest"`

Closes #5