### PR TITLE
feat: add minimal HCL parser contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@
 - Python is pinned to `^3.12`. Use Poetry inside the devcontainer for orchestration and Ruff for linting/formatting.
 - `tool.poetry.package-mode = false` right now. Do not assume there is already an installable package or entrypoint.
 - Do not run `poetry` on the host machine for normal repo work. Keep Poetry environments and installs inside the devcontainer flow.
+- The minimal HCL parser contract is expected to consume `python-hcl2` output rather than inventing a separate raw-text parser first.
 
 ## Delivery Workflow
 

--- a/docs/architecture/IMPLEMENTATION_OUTLINE.md
+++ b/docs/architecture/IMPLEMENTATION_OUTLINE.md
@@ -69,6 +69,9 @@ The first HCL implementation should support:
 
 It should not initially try to recreate the full `1.x` expression system.
 
+The current parser direction assumes `python-hcl2` as the HCL text frontend and
+then maps its loaded block output into typed config contracts.
+
 ## Service Boundary Reminder
 
 Early code should preserve the logical split established by the RFCs even if the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 package-mode = false
 
 [tool.poetry.dependencies]
+python-hcl2 = "^7.3.1"
 python = "^3.12"
 
 [tool.poetry.group.dev.dependencies]

--- a/src/canonical_discovery/config/__init__.py
+++ b/src/canonical_discovery/config/__init__.py
@@ -13,7 +13,7 @@ from canonical_discovery.config.hcl_models import (
     ProjectionScope,
     SourceBlock,
 )
-from canonical_discovery.config.parser import HclConfigError, parse_hcl_document
+from canonical_discovery.config.parser import HclConfigError, parse_hcl_document, parse_hcl_text
 
 __all__ = [
     "AuthorityBlock",
@@ -24,6 +24,7 @@ __all__ = [
     "HclConfigError",
     "HclDocument",
     "parse_hcl_document",
+    "parse_hcl_text",
     "PolicyBlock",
     "PolicyClassify",
     "ProjectionBlock",

--- a/src/canonical_discovery/config/__init__.py
+++ b/src/canonical_discovery/config/__init__.py
@@ -13,6 +13,7 @@ from canonical_discovery.config.hcl_models import (
     ProjectionScope,
     SourceBlock,
 )
+from canonical_discovery.config.parser import HclConfigError, parse_hcl_document
 
 __all__ = [
     "AuthorityBlock",
@@ -20,7 +21,9 @@ __all__ = [
     "AuthorityField",
     "AuthorityRule",
     "AuthorityScope",
+    "HclConfigError",
     "HclDocument",
+    "parse_hcl_document",
     "PolicyBlock",
     "PolicyClassify",
     "ProjectionBlock",

--- a/src/canonical_discovery/config/parser.py
+++ b/src/canonical_discovery/config/parser.py
@@ -31,18 +31,23 @@ def parse_hcl_document(data: dict[str, Any]) -> HclDocument:
         raise HclConfigError("HCL document input must be a mapping")
 
     return HclDocument(
-        sources=tuple(parse_source_block(item) for item in require_list(data, "sources")),
-        policies=tuple(parse_policy_block(item) for item in require_list(data, "policies")),
+        sources=tuple(
+            parse_source_block(name, body) for name, body in require_block_map(data, "source")
+        ),
+        policies=tuple(
+            parse_policy_block(name, body) for name, body in require_block_map(data, "policy")
+        ),
         projections=tuple(
-            parse_projection_block(item) for item in require_list(data, "projections")
+            parse_projection_block(name, body)
+            for name, body in require_block_map(data, "projection")
         ),
     )
 
 
-def parse_source_block(data: Any) -> SourceBlock:
+def parse_source_block(name: str, data: Any) -> SourceBlock:
     block = require_mapping(data, "source block")
     return SourceBlock(
-        name=require_string(block, "name"),
+        name=name,
         api_type=require_string(block, "api_type"),
         authority=parse_authority_block(block["authority"]) if "authority" in block else None,
         options=require_mapping(block.get("options", {}), "source options"),
@@ -52,33 +57,39 @@ def parse_source_block(data: Any) -> SourceBlock:
 def parse_authority_block(data: Any) -> AuthorityBlock:
     block = require_mapping(data, "authority block")
     return AuthorityBlock(
-        scopes=tuple(parse_authority_scope(item) for item in require_list(block, "scopes")),
+        scopes=tuple(
+            parse_authority_scope(name, body) for name, body in require_block_map(block, "scope")
+        ),
     )
 
 
-def parse_authority_scope(data: Any) -> AuthorityScope:
+def parse_authority_scope(name: str, data: Any) -> AuthorityScope:
     block = require_mapping(data, "authority scope")
     return AuthorityScope(
-        scope=parse_node_scope(require_string(block, "scope")),
+        scope=parse_node_scope(name),
         categories=tuple(
-            parse_authority_category(item) for item in require_list(block, "categories")
+            parse_authority_category(category_name, category_body)
+            for category_name, category_body in require_block_map(block, "category")
         ),
-        fields=tuple(parse_authority_field(item) for item in require_list(block, "fields")),
+        fields=tuple(
+            parse_authority_field(field_name, field_body)
+            for field_name, field_body in require_block_map(block, "field")
+        ),
     )
 
 
-def parse_authority_category(data: Any) -> AuthorityCategory:
+def parse_authority_category(name: str, data: Any) -> AuthorityCategory:
     block = require_mapping(data, "authority category")
     return AuthorityCategory(
-        category=parse_category(require_string(block, "category")),
+        category=parse_category(name),
         rule=parse_authority_rule(block),
     )
 
 
-def parse_authority_field(data: Any) -> AuthorityField:
+def parse_authority_field(name: str, data: Any) -> AuthorityField:
     block = require_mapping(data, "authority field")
     return AuthorityField(
-        name=require_string(block, "name"),
+        name=name,
         rule=parse_authority_rule(block),
     )
 
@@ -92,40 +103,44 @@ def parse_authority_rule(data: Any) -> AuthorityRule:
     )
 
 
-def parse_policy_block(data: Any) -> PolicyBlock:
+def parse_policy_block(name: str, data: Any) -> PolicyBlock:
     block = require_mapping(data, "policy block")
     return PolicyBlock(
-        name=require_string(block, "name"),
+        name=name,
         classifications=tuple(
-            parse_policy_classify(item) for item in require_list(block, "classifications")
+            parse_policy_classify(target, classify_body)
+            for target, classify_body in require_block_map(block, "classify")
         ),
     )
 
 
-def parse_policy_classify(data: Any) -> PolicyClassify:
+def parse_policy_classify(name: str, data: Any) -> PolicyClassify:
     block = require_mapping(data, "policy classify")
     return PolicyClassify(
-        target=parse_node_scope(require_string(block, "target")),
+        target=parse_node_scope(name),
         attributes=require_mapping(block.get("attributes", {}), "policy classify attributes"),
     )
 
 
-def parse_projection_block(data: Any) -> ProjectionBlock:
+def parse_projection_block(name: str, data: Any) -> ProjectionBlock:
     block = require_mapping(data, "projection block")
     return ProjectionBlock(
-        name=require_string(block, "name"),
+        name=name,
         include_scopes=tuple(
             parse_node_scope(value)
             for value in require_string_list(block.get("include_scopes", []), "include_scopes")
         ),
-        scopes=tuple(parse_projection_scope(item) for item in require_list(block, "scopes")),
+        scopes=tuple(
+            parse_projection_scope(scope_name, scope_body)
+            for scope_name, scope_body in require_block_map(block, "scope")
+        ),
     )
 
 
-def parse_projection_scope(data: Any) -> ProjectionScope:
+def parse_projection_scope(name: str, data: Any) -> ProjectionScope:
     block = require_mapping(data, "projection scope")
     return ProjectionScope(
-        scope=parse_node_scope(require_string(block, "scope")),
+        scope=parse_node_scope(name),
         resource=block.get("resource")
         if block.get("resource") is None
         else require_string(block, "resource"),
@@ -167,6 +182,19 @@ def require_mapping(value: Any, label: str) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise HclConfigError(f"{label} must be a mapping")
     return value
+
+
+def require_block_map(mapping: dict[str, Any], key: str) -> list[tuple[str, Any]]:
+    value = mapping.get(key, {})
+    if not isinstance(value, dict):
+        raise HclConfigError(f"{key} blocks must be a mapping")
+
+    parsed: list[tuple[str, Any]] = []
+    for name, body in value.items():
+        if not isinstance(name, str) or name == "":
+            raise HclConfigError(f"{key} block names must be non-empty strings")
+        parsed.append((name, body))
+    return parsed
 
 
 def require_list(mapping: dict[str, Any], key: str) -> list[Any]:

--- a/src/canonical_discovery/config/parser.py
+++ b/src/canonical_discovery/config/parser.py
@@ -1,0 +1,195 @@
+"""Minimal parser contract for the typed HCL configuration models."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from canonical_discovery.config.hcl_models import (
+    AuthorityBlock,
+    AuthorityCategory,
+    AuthorityField,
+    AuthorityRule,
+    AuthorityScope,
+    HclDocument,
+    PolicyBlock,
+    PolicyClassify,
+    ProjectionBlock,
+    ProjectionScope,
+    SourceBlock,
+)
+from canonical_discovery.core import AuthorityMode, AuthorityTier, Category, NodeScope
+
+
+class HclConfigError(ValueError):
+    """Raised when a minimal HCL document shape is invalid."""
+
+
+def parse_hcl_document(data: dict[str, Any]) -> HclDocument:
+    """Parse a minimal HCL-like mapping into typed configuration contracts."""
+
+    if not isinstance(data, dict):
+        raise HclConfigError("HCL document input must be a mapping")
+
+    return HclDocument(
+        sources=tuple(parse_source_block(item) for item in require_list(data, "sources")),
+        policies=tuple(parse_policy_block(item) for item in require_list(data, "policies")),
+        projections=tuple(
+            parse_projection_block(item) for item in require_list(data, "projections")
+        ),
+    )
+
+
+def parse_source_block(data: Any) -> SourceBlock:
+    block = require_mapping(data, "source block")
+    return SourceBlock(
+        name=require_string(block, "name"),
+        api_type=require_string(block, "api_type"),
+        authority=parse_authority_block(block["authority"]) if "authority" in block else None,
+        options=require_mapping(block.get("options", {}), "source options"),
+    )
+
+
+def parse_authority_block(data: Any) -> AuthorityBlock:
+    block = require_mapping(data, "authority block")
+    return AuthorityBlock(
+        scopes=tuple(parse_authority_scope(item) for item in require_list(block, "scopes")),
+    )
+
+
+def parse_authority_scope(data: Any) -> AuthorityScope:
+    block = require_mapping(data, "authority scope")
+    return AuthorityScope(
+        scope=parse_node_scope(require_string(block, "scope")),
+        categories=tuple(
+            parse_authority_category(item) for item in require_list(block, "categories")
+        ),
+        fields=tuple(parse_authority_field(item) for item in require_list(block, "fields")),
+    )
+
+
+def parse_authority_category(data: Any) -> AuthorityCategory:
+    block = require_mapping(data, "authority category")
+    return AuthorityCategory(
+        category=parse_category(require_string(block, "category")),
+        rule=parse_authority_rule(block),
+    )
+
+
+def parse_authority_field(data: Any) -> AuthorityField:
+    block = require_mapping(data, "authority field")
+    return AuthorityField(
+        name=require_string(block, "name"),
+        rule=parse_authority_rule(block),
+    )
+
+
+def parse_authority_rule(data: Any) -> AuthorityRule:
+    block = require_mapping(data, "authority rule")
+    return AuthorityRule(
+        tier=parse_authority_tier(require_string(block, "tier")),
+        mode=parse_authority_mode(require_string(block, "mode")),
+        confidence=parse_optional_number(block.get("confidence"), "confidence"),
+    )
+
+
+def parse_policy_block(data: Any) -> PolicyBlock:
+    block = require_mapping(data, "policy block")
+    return PolicyBlock(
+        name=require_string(block, "name"),
+        classifications=tuple(
+            parse_policy_classify(item) for item in require_list(block, "classifications")
+        ),
+    )
+
+
+def parse_policy_classify(data: Any) -> PolicyClassify:
+    block = require_mapping(data, "policy classify")
+    return PolicyClassify(
+        target=parse_node_scope(require_string(block, "target")),
+        attributes=require_mapping(block.get("attributes", {}), "policy classify attributes"),
+    )
+
+
+def parse_projection_block(data: Any) -> ProjectionBlock:
+    block = require_mapping(data, "projection block")
+    return ProjectionBlock(
+        name=require_string(block, "name"),
+        include_scopes=tuple(
+            parse_node_scope(value)
+            for value in require_string_list(block.get("include_scopes", []), "include_scopes")
+        ),
+        scopes=tuple(parse_projection_scope(item) for item in require_list(block, "scopes")),
+    )
+
+
+def parse_projection_scope(data: Any) -> ProjectionScope:
+    block = require_mapping(data, "projection scope")
+    return ProjectionScope(
+        scope=parse_node_scope(require_string(block, "scope")),
+        resource=block.get("resource")
+        if block.get("resource") is None
+        else require_string(block, "resource"),
+    )
+
+
+def parse_node_scope(value: str) -> NodeScope:
+    return parse_enum(value, NodeScope, "node scope")
+
+
+def parse_category(value: str) -> Category:
+    return parse_enum(value, Category, "category")
+
+
+def parse_authority_tier(value: str) -> AuthorityTier:
+    return parse_enum(value, AuthorityTier, "authority tier")
+
+
+def parse_authority_mode(value: str) -> AuthorityMode:
+    return parse_enum(value, AuthorityMode, "authority mode")
+
+
+def parse_enum(value: str, enum_type: type, label: str):
+    try:
+        return enum_type(value)
+    except ValueError as exc:
+        raise HclConfigError(f"invalid {label}: '{value}'") from exc
+
+
+def parse_optional_number(value: Any, label: str) -> int | float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise HclConfigError(f"{label} must be a number")
+    return value
+
+
+def require_mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise HclConfigError(f"{label} must be a mapping")
+    return value
+
+
+def require_list(mapping: dict[str, Any], key: str) -> list[Any]:
+    value = mapping.get(key, [])
+    if not isinstance(value, list):
+        raise HclConfigError(f"{key} must be a list")
+    return value
+
+
+def require_string(mapping: dict[str, Any], key: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or value == "":
+        raise HclConfigError(f"{key} must be a non-empty string")
+    return value
+
+
+def require_string_list(value: Any, key: str) -> list[str]:
+    if not isinstance(value, list):
+        raise HclConfigError(f"{key} must be a list")
+
+    parsed: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or item == "":
+            raise HclConfigError(f"{key} entries must be non-empty strings")
+        parsed.append(item)
+    return parsed

--- a/src/canonical_discovery/config/parser.py
+++ b/src/canonical_discovery/config/parser.py
@@ -75,13 +75,16 @@ def parse_source_block(name: str, data: Any) -> SourceBlock:
 
 
 def parse_authority_block(data: Any) -> AuthorityBlock:
-    block = require_single_block(data, "authority block")
-    return AuthorityBlock(
-        scopes=tuple(
+    blocks = require_block_list(data, "authority block")
+    scopes: list[AuthorityScope] = []
+
+    for block in blocks:
+        scopes.extend(
             parse_authority_scope(name, body)
             for name, body in require_labeled_blocks(block, "scope")
-        ),
-    )
+        )
+
+    return AuthorityBlock(scopes=tuple(scopes))
 
 
 def parse_authority_scope(name: str, data: Any) -> AuthorityScope:
@@ -205,12 +208,10 @@ def require_mapping(value: Any, label: str) -> dict[str, Any]:
     return value
 
 
-def require_single_block(value: Any, label: str) -> dict[str, Any]:
+def require_block_list(value: Any, label: str) -> list[dict[str, Any]]:
     if not isinstance(value, list):
         raise HclConfigError(f"{label} must be a list")
-    if len(value) != 1:
-        raise HclConfigError(f"{label} must contain exactly one block")
-    return require_mapping(value[0], label)
+    return [require_mapping(item, label) for item in value]
 
 
 def require_labeled_blocks(mapping: dict[str, Any], key: str) -> list[tuple[str, Any]]:

--- a/src/canonical_discovery/config/parser.py
+++ b/src/canonical_discovery/config/parser.py
@@ -118,7 +118,7 @@ def parse_policy_classify(name: str, data: Any) -> PolicyClassify:
     block = require_mapping(data, "policy classify")
     return PolicyClassify(
         target=parse_node_scope(name),
-        attributes=require_mapping(block.get("attributes", {}), "policy classify attributes"),
+        attributes=block,
     )
 
 

--- a/src/canonical_discovery/config/parser.py
+++ b/src/canonical_discovery/config/parser.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from io import StringIO
 from typing import Any
+
+import hcl2
 
 from canonical_discovery.config.hcl_models import (
     AuthorityBlock,
@@ -24,41 +27,59 @@ class HclConfigError(ValueError):
     """Raised when a minimal HCL document shape is invalid."""
 
 
+def parse_hcl_text(text: str) -> HclDocument:
+    """Parse raw HCL text using python-hcl2 and map it to typed contracts."""
+
+    if text == "":
+        raise HclConfigError("HCL text input must be non-empty")
+
+    try:
+        loaded = hcl2.load(StringIO(text))
+    except Exception as exc:  # pragma: no cover
+        raise HclConfigError(f"failed to parse HCL text: {exc}") from exc
+
+    return parse_hcl_document(loaded)
+
+
 def parse_hcl_document(data: dict[str, Any]) -> HclDocument:
-    """Parse a minimal HCL-like mapping into typed configuration contracts."""
+    """Parse python-hcl2 output into typed configuration contracts."""
 
     if not isinstance(data, dict):
         raise HclConfigError("HCL document input must be a mapping")
 
     return HclDocument(
         sources=tuple(
-            parse_source_block(name, body) for name, body in require_block_map(data, "source")
+            parse_source_block(name, body) for name, body in require_labeled_blocks(data, "source")
         ),
         policies=tuple(
-            parse_policy_block(name, body) for name, body in require_block_map(data, "policy")
+            parse_policy_block(name, body) for name, body in require_labeled_blocks(data, "policy")
         ),
         projections=tuple(
             parse_projection_block(name, body)
-            for name, body in require_block_map(data, "projection")
+            for name, body in require_labeled_blocks(data, "projection")
         ),
     )
 
 
 def parse_source_block(name: str, data: Any) -> SourceBlock:
     block = require_mapping(data, "source block")
+    authority_value = block.get("authority")
     return SourceBlock(
         name=name,
         api_type=require_string(block, "api_type"),
-        authority=parse_authority_block(block["authority"]) if "authority" in block else None,
-        options=require_mapping(block.get("options", {}), "source options"),
+        authority=parse_authority_block(authority_value) if authority_value is not None else None,
+        options={
+            key: value for key, value in block.items() if key not in {"api_type", "authority"}
+        },
     )
 
 
 def parse_authority_block(data: Any) -> AuthorityBlock:
-    block = require_mapping(data, "authority block")
+    block = require_single_block(data, "authority block")
     return AuthorityBlock(
         scopes=tuple(
-            parse_authority_scope(name, body) for name, body in require_block_map(block, "scope")
+            parse_authority_scope(name, body)
+            for name, body in require_labeled_blocks(block, "scope")
         ),
     )
 
@@ -69,11 +90,11 @@ def parse_authority_scope(name: str, data: Any) -> AuthorityScope:
         scope=parse_node_scope(name),
         categories=tuple(
             parse_authority_category(category_name, category_body)
-            for category_name, category_body in require_block_map(block, "category")
+            for category_name, category_body in require_labeled_blocks(block, "category")
         ),
         fields=tuple(
             parse_authority_field(field_name, field_body)
-            for field_name, field_body in require_block_map(block, "field")
+            for field_name, field_body in require_labeled_blocks(block, "field")
         ),
     )
 
@@ -109,7 +130,7 @@ def parse_policy_block(name: str, data: Any) -> PolicyBlock:
         name=name,
         classifications=tuple(
             parse_policy_classify(target, classify_body)
-            for target, classify_body in require_block_map(block, "classify")
+            for target, classify_body in require_labeled_blocks(block, "classify")
         ),
     )
 
@@ -118,7 +139,7 @@ def parse_policy_classify(name: str, data: Any) -> PolicyClassify:
     block = require_mapping(data, "policy classify")
     return PolicyClassify(
         target=parse_node_scope(name),
-        attributes=block,
+        attributes=dict(block),
     )
 
 
@@ -132,7 +153,7 @@ def parse_projection_block(name: str, data: Any) -> ProjectionBlock:
         ),
         scopes=tuple(
             parse_projection_scope(scope_name, scope_body)
-            for scope_name, scope_body in require_block_map(block, "scope")
+            for scope_name, scope_body in require_labeled_blocks(block, "scope")
         ),
     )
 
@@ -184,24 +205,29 @@ def require_mapping(value: Any, label: str) -> dict[str, Any]:
     return value
 
 
-def require_block_map(mapping: dict[str, Any], key: str) -> list[tuple[str, Any]]:
-    value = mapping.get(key, {})
-    if not isinstance(value, dict):
-        raise HclConfigError(f"{key} blocks must be a mapping")
+def require_single_block(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, list):
+        raise HclConfigError(f"{label} must be a list")
+    if len(value) != 1:
+        raise HclConfigError(f"{label} must contain exactly one block")
+    return require_mapping(value[0], label)
+
+
+def require_labeled_blocks(mapping: dict[str, Any], key: str) -> list[tuple[str, Any]]:
+    value = mapping.get(key, [])
+    if not isinstance(value, list):
+        raise HclConfigError(f"{key} blocks must be a list")
 
     parsed: list[tuple[str, Any]] = []
-    for name, body in value.items():
+    for item in value:
+        block = require_mapping(item, f"{key} block")
+        if len(block) != 1:
+            raise HclConfigError(f"{key} blocks must contain exactly one labeled entry")
+        name, body = next(iter(block.items()))
         if not isinstance(name, str) or name == "":
             raise HclConfigError(f"{key} block names must be non-empty strings")
         parsed.append((name, body))
     return parsed
-
-
-def require_list(mapping: dict[str, Any], key: str) -> list[Any]:
-    value = mapping.get(key, [])
-    if not isinstance(value, list):
-        raise HclConfigError(f"{key} must be a list")
-    return value
 
 
 def require_string(mapping: dict[str, Any], key: str) -> str:

--- a/tests/test_hcl_parser.py
+++ b/tests/test_hcl_parser.py
@@ -12,55 +12,48 @@ class HclParserTests(unittest.TestCase):
     def test_parse_hcl_document_supports_minimal_valid_shape(self) -> None:
         document = parse_hcl_document(
             {
-                "sources": [
-                    {
-                        "name": "vmware",
+                "source": {
+                    "vmware": {
                         "api_type": "vmware",
                         "authority": {
-                            "scopes": [
-                                {
-                                    "scope": "physical_device",
-                                    "categories": [
-                                        {
-                                            "category": "hardware_inventory",
+                            "scope": {
+                                "physical_device": {
+                                    "category": {
+                                        "hardware_inventory": {
                                             "tier": "supplemental",
                                             "confidence": 20,
                                             "mode": "fill_if_missing",
                                         }
-                                    ],
-                                    "fields": [
-                                        {
-                                            "name": "serial",
+                                    },
+                                    "field": {
+                                        "serial": {
                                             "tier": "observe_only",
                                             "mode": "observe_only",
                                         }
-                                    ],
+                                    },
                                 }
-                            ]
+                            }
                         },
                     }
-                ],
-                "policies": [
-                    {
-                        "name": "campus-defaults",
-                        "classifications": [
-                            {
-                                "target": "location",
+                },
+                "policy": {
+                    "campus-defaults": {
+                        "classify": {
+                            "location": {
                                 "attributes": {"site_map": "regex/site_map"},
                             }
-                        ],
+                        }
                     }
-                ],
-                "projections": [
-                    {
-                        "name": "netbox",
+                },
+                "projection": {
+                    "netbox": {
                         "include_scopes": ["physical_device", "port"],
-                        "scopes": [
-                            {"scope": "physical_device", "resource": "dcim.devices"},
-                            {"scope": "port", "resource": "dcim.interfaces"},
-                        ],
+                        "scope": {
+                            "physical_device": {"resource": "dcim.devices"},
+                            "port": {"resource": "dcim.interfaces"},
+                        },
                     }
-                ],
+                },
             }
         )
 
@@ -88,13 +81,12 @@ class HclParserTests(unittest.TestCase):
         with self.assertRaisesRegex(HclConfigError, "invalid node scope"):
             parse_hcl_document(
                 {
-                    "sources": [
-                        {
-                            "name": "vmware",
+                    "source": {
+                        "vmware": {
                             "api_type": "vmware",
-                            "authority": {"scopes": [{"scope": "not_a_scope"}]},
+                            "authority": {"scope": {"not_a_scope": {}}},
                         }
-                    ]
+                    }
                 }
             )
 
@@ -102,26 +94,23 @@ class HclParserTests(unittest.TestCase):
         with self.assertRaisesRegex(HclConfigError, "invalid authority tier"):
             parse_hcl_document(
                 {
-                    "sources": [
-                        {
-                            "name": "vmware",
+                    "source": {
+                        "vmware": {
                             "api_type": "vmware",
                             "authority": {
-                                "scopes": [
-                                    {
-                                        "scope": "physical_device",
-                                        "categories": [
-                                            {
-                                                "category": "hardware_inventory",
+                                "scope": {
+                                    "physical_device": {
+                                        "category": {
+                                            "hardware_inventory": {
                                                 "tier": "wrong",
                                                 "mode": "replace",
                                             }
-                                        ],
+                                        }
                                     }
-                                ]
+                                }
                             },
                         }
-                    ]
+                    }
                 }
             )
 
@@ -129,33 +118,34 @@ class HclParserTests(unittest.TestCase):
         with self.assertRaisesRegex(HclConfigError, "confidence must be a number"):
             parse_hcl_document(
                 {
-                    "sources": [
-                        {
-                            "name": "vmware",
+                    "source": {
+                        "vmware": {
                             "api_type": "vmware",
                             "authority": {
-                                "scopes": [
-                                    {
-                                        "scope": "physical_device",
-                                        "categories": [
-                                            {
-                                                "category": "hardware_inventory",
+                                "scope": {
+                                    "physical_device": {
+                                        "category": {
+                                            "hardware_inventory": {
                                                 "tier": "supplemental",
                                                 "confidence": "high",
                                                 "mode": "replace",
                                             }
-                                        ],
+                                        }
                                     }
-                                ]
+                                }
                             },
                         }
-                    ]
+                    }
                 }
             )
 
     def test_parse_hcl_document_rejects_non_list_sections(self) -> None:
-        with self.assertRaisesRegex(HclConfigError, "sources must be a list"):
-            parse_hcl_document({"sources": {}})
+        with self.assertRaisesRegex(HclConfigError, "source blocks must be a mapping"):
+            parse_hcl_document({"source": []})
+
+    def test_parse_hcl_document_rejects_empty_block_name(self) -> None:
+        with self.assertRaisesRegex(HclConfigError, "source block names must be non-empty strings"):
+            parse_hcl_document({"source": {"": {"api_type": "vmware"}}})
 
     def test_parse_hcl_document_rejects_non_mapping_document(self) -> None:
         with self.assertRaisesRegex(HclConfigError, "HCL document input must be a mapping"):

--- a/tests/test_hcl_parser.py
+++ b/tests/test_hcl_parser.py
@@ -1,0 +1,166 @@
+"""Tests for the minimal HCL parser contract."""
+
+from __future__ import annotations
+
+import unittest
+
+from canonical_discovery.config import HclConfigError, parse_hcl_document
+from canonical_discovery.core import AuthorityMode, AuthorityTier, Category, NodeScope
+
+
+class HclParserTests(unittest.TestCase):
+    def test_parse_hcl_document_supports_minimal_valid_shape(self) -> None:
+        document = parse_hcl_document(
+            {
+                "sources": [
+                    {
+                        "name": "vmware",
+                        "api_type": "vmware",
+                        "authority": {
+                            "scopes": [
+                                {
+                                    "scope": "physical_device",
+                                    "categories": [
+                                        {
+                                            "category": "hardware_inventory",
+                                            "tier": "supplemental",
+                                            "confidence": 20,
+                                            "mode": "fill_if_missing",
+                                        }
+                                    ],
+                                    "fields": [
+                                        {
+                                            "name": "serial",
+                                            "tier": "observe_only",
+                                            "mode": "observe_only",
+                                        }
+                                    ],
+                                }
+                            ]
+                        },
+                    }
+                ],
+                "policies": [
+                    {
+                        "name": "campus-defaults",
+                        "classifications": [
+                            {
+                                "target": "location",
+                                "attributes": {"site_map": "regex/site_map"},
+                            }
+                        ],
+                    }
+                ],
+                "projections": [
+                    {
+                        "name": "netbox",
+                        "include_scopes": ["physical_device", "port"],
+                        "scopes": [
+                            {"scope": "physical_device", "resource": "dcim.devices"},
+                            {"scope": "port", "resource": "dcim.interfaces"},
+                        ],
+                    }
+                ],
+            }
+        )
+
+        source = document.sources[0]
+        authority_scope = source.authority.scopes[0]  # type: ignore[union-attr]
+        authority_category = authority_scope.categories[0]
+        authority_field = authority_scope.fields[0]
+        policy = document.policies[0]
+        projection = document.projections[0]
+
+        self.assertEqual(source.name, "vmware")
+        self.assertEqual(source.api_type, "vmware")
+        self.assertEqual(authority_scope.scope, NodeScope.PHYSICAL_DEVICE)
+        self.assertEqual(authority_category.category, Category.HARDWARE_INVENTORY)
+        self.assertEqual(authority_category.rule.tier, AuthorityTier.SUPPLEMENTAL)
+        self.assertEqual(authority_category.rule.mode, AuthorityMode.FILL_IF_MISSING)
+        self.assertEqual(authority_category.rule.confidence, 20)
+        self.assertEqual(authority_field.name, "serial")
+        self.assertEqual(authority_field.rule.confidence, None)
+        self.assertEqual(policy.classifications[0].target, NodeScope.LOCATION)
+        self.assertEqual(projection.include_scopes, (NodeScope.PHYSICAL_DEVICE, NodeScope.PORT))
+        self.assertEqual(projection.scopes[1].scope, NodeScope.PORT)
+
+    def test_parse_hcl_document_rejects_invalid_scope_name(self) -> None:
+        with self.assertRaisesRegex(HclConfigError, "invalid node scope"):
+            parse_hcl_document(
+                {
+                    "sources": [
+                        {
+                            "name": "vmware",
+                            "api_type": "vmware",
+                            "authority": {"scopes": [{"scope": "not_a_scope"}]},
+                        }
+                    ]
+                }
+            )
+
+    def test_parse_hcl_document_rejects_invalid_authority_tier(self) -> None:
+        with self.assertRaisesRegex(HclConfigError, "invalid authority tier"):
+            parse_hcl_document(
+                {
+                    "sources": [
+                        {
+                            "name": "vmware",
+                            "api_type": "vmware",
+                            "authority": {
+                                "scopes": [
+                                    {
+                                        "scope": "physical_device",
+                                        "categories": [
+                                            {
+                                                "category": "hardware_inventory",
+                                                "tier": "wrong",
+                                                "mode": "replace",
+                                            }
+                                        ],
+                                    }
+                                ]
+                            },
+                        }
+                    ]
+                }
+            )
+
+    def test_parse_hcl_document_rejects_non_numeric_confidence(self) -> None:
+        with self.assertRaisesRegex(HclConfigError, "confidence must be a number"):
+            parse_hcl_document(
+                {
+                    "sources": [
+                        {
+                            "name": "vmware",
+                            "api_type": "vmware",
+                            "authority": {
+                                "scopes": [
+                                    {
+                                        "scope": "physical_device",
+                                        "categories": [
+                                            {
+                                                "category": "hardware_inventory",
+                                                "tier": "supplemental",
+                                                "confidence": "high",
+                                                "mode": "replace",
+                                            }
+                                        ],
+                                    }
+                                ]
+                            },
+                        }
+                    ]
+                }
+            )
+
+    def test_parse_hcl_document_rejects_non_list_sections(self) -> None:
+        with self.assertRaisesRegex(HclConfigError, "sources must be a list"):
+            parse_hcl_document({"sources": {}})
+
+    def test_parse_hcl_document_rejects_non_mapping_document(self) -> None:
+        with self.assertRaisesRegex(HclConfigError, "HCL document input must be a mapping"):
+            parse_hcl_document([])  # type: ignore[arg-type]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hcl_parser.py
+++ b/tests/test_hcl_parser.py
@@ -164,6 +164,40 @@ class HclParserTests(unittest.TestCase):
                 }
             )
 
+    def test_parse_hcl_document_merges_repeated_authority_blocks(self) -> None:
+        loaded = hcl2.load(
+            StringIO(
+                'source "vmware" {\n'
+                '  api_type = "vmware"\n'
+                "  authority {\n"
+                '    scope "virtual_machine" {\n'
+                '      category "identity" {\n'
+                '        tier = "authoritative"\n'
+                '        mode = "replace"\n'
+                "      }\n"
+                "    }\n"
+                "  }\n"
+                "  authority {\n"
+                '    scope "physical_device" {\n'
+                '      category "hardware_inventory" {\n'
+                '        tier = "supplemental"\n'
+                '        mode = "fill_if_missing"\n'
+                "      }\n"
+                "    }\n"
+                "  }\n"
+                "}\n"
+            )
+        )
+
+        document = parse_hcl_document(loaded)
+        source = document.sources[0]
+        scopes = source.authority.scopes  # type: ignore[union-attr]
+
+        self.assertEqual(
+            tuple(scope.scope for scope in scopes),
+            (NodeScope.VIRTUAL_MACHINE, NodeScope.PHYSICAL_DEVICE),
+        )
+
     def test_parse_hcl_document_rejects_non_list_sections(self) -> None:
         with self.assertRaisesRegex(HclConfigError, "source blocks must be a list"):
             parse_hcl_document({"source": {}})

--- a/tests/test_hcl_parser.py
+++ b/tests/test_hcl_parser.py
@@ -3,59 +3,52 @@
 from __future__ import annotations
 
 import unittest
+from io import StringIO
 
-from canonical_discovery.config import HclConfigError, parse_hcl_document
+import hcl2
+
+from canonical_discovery.config import HclConfigError, parse_hcl_document, parse_hcl_text
 from canonical_discovery.core import AuthorityMode, AuthorityTier, Category, NodeScope
 
 
 class HclParserTests(unittest.TestCase):
-    def test_parse_hcl_document_supports_minimal_valid_shape(self) -> None:
-        document = parse_hcl_document(
-            {
-                "source": {
-                    "vmware": {
-                        "api_type": "vmware",
-                        "authority": {
-                            "scope": {
-                                "physical_device": {
-                                    "category": {
-                                        "hardware_inventory": {
-                                            "tier": "supplemental",
-                                            "confidence": 20,
-                                            "mode": "fill_if_missing",
-                                        }
-                                    },
-                                    "field": {
-                                        "serial": {
-                                            "tier": "observe_only",
-                                            "mode": "observe_only",
-                                        }
-                                    },
-                                }
-                            }
-                        },
-                    }
-                },
-                "policy": {
-                    "campus-defaults": {
-                        "classify": {
-                            "location": {
-                                "site_map": "regex/site_map",
-                            }
-                        }
-                    }
-                },
-                "projection": {
-                    "netbox": {
-                        "include_scopes": ["physical_device", "port"],
-                        "scope": {
-                            "physical_device": {"resource": "dcim.devices"},
-                            "port": {"resource": "dcim.interfaces"},
-                        },
-                    }
-                },
-            }
+    def test_parse_hcl_document_supports_python_hcl2_output_shape(self) -> None:
+        loaded = hcl2.load(
+            StringIO(
+                'source "vmware" {\n'
+                '  api_type = "vmware"\n'
+                "  authority {\n"
+                '    scope "physical_device" {\n'
+                '      category "hardware_inventory" {\n'
+                '        tier = "supplemental"\n'
+                "        confidence = 20\n"
+                '        mode = "fill_if_missing"\n'
+                "      }\n"
+                '      field "serial" {\n'
+                '        tier = "observe_only"\n'
+                '        mode = "observe_only"\n'
+                "      }\n"
+                "    }\n"
+                "  }\n"
+                "}\n"
+                'policy "campus-defaults" {\n'
+                '  classify "location" {\n'
+                '    site_map = "regex/site_map"\n'
+                "  }\n"
+                "}\n"
+                'projection "netbox" {\n'
+                '  include_scopes = ["physical_device", "port"]\n'
+                '  scope "physical_device" {\n'
+                '    resource = "dcim.devices"\n'
+                "  }\n"
+                '  scope "port" {\n'
+                '    resource = "dcim.interfaces"\n'
+                "  }\n"
+                "}\n"
+            )
         )
+
+        document = parse_hcl_document(loaded)
 
         source = document.sources[0]
         authority_scope = source.authority.scopes[0]  # type: ignore[union-attr]
@@ -78,16 +71,31 @@ class HclParserTests(unittest.TestCase):
         self.assertEqual(projection.include_scopes, (NodeScope.PHYSICAL_DEVICE, NodeScope.PORT))
         self.assertEqual(projection.scopes[1].scope, NodeScope.PORT)
 
+    def test_parse_hcl_text_uses_python_hcl2_backend(self) -> None:
+        document = parse_hcl_text(
+            'policy "campus-defaults" {\n'
+            '  classify "location" {\n'
+            '    site_map = "regex/site_map"\n'
+            "  }\n"
+            "}\n"
+        )
+
+        self.assertEqual(
+            document.policies[0].classifications[0].attributes["site_map"], "regex/site_map"
+        )
+
     def test_parse_hcl_document_rejects_invalid_scope_name(self) -> None:
         with self.assertRaisesRegex(HclConfigError, "invalid node scope"):
             parse_hcl_document(
                 {
-                    "source": {
-                        "vmware": {
-                            "api_type": "vmware",
-                            "authority": {"scope": {"not_a_scope": {}}},
+                    "source": [
+                        {
+                            "vmware": {
+                                "api_type": "vmware",
+                                "authority": [{"scope": [{"not_a_scope": {}}]}],
+                            }
                         }
-                    }
+                    ]
                 }
             )
 
@@ -95,23 +103,31 @@ class HclParserTests(unittest.TestCase):
         with self.assertRaisesRegex(HclConfigError, "invalid authority tier"):
             parse_hcl_document(
                 {
-                    "source": {
-                        "vmware": {
-                            "api_type": "vmware",
-                            "authority": {
-                                "scope": {
-                                    "physical_device": {
-                                        "category": {
-                                            "hardware_inventory": {
-                                                "tier": "wrong",
-                                                "mode": "replace",
+                    "source": [
+                        {
+                            "vmware": {
+                                "api_type": "vmware",
+                                "authority": [
+                                    {
+                                        "scope": [
+                                            {
+                                                "physical_device": {
+                                                    "category": [
+                                                        {
+                                                            "hardware_inventory": {
+                                                                "tier": "wrong",
+                                                                "mode": "replace",
+                                                            }
+                                                        }
+                                                    ]
+                                                }
                                             }
-                                        }
+                                        ]
                                     }
-                                }
-                            },
+                                ],
+                            }
                         }
-                    }
+                    ]
                 }
             )
 
@@ -119,38 +135,46 @@ class HclParserTests(unittest.TestCase):
         with self.assertRaisesRegex(HclConfigError, "confidence must be a number"):
             parse_hcl_document(
                 {
-                    "source": {
-                        "vmware": {
-                            "api_type": "vmware",
-                            "authority": {
-                                "scope": {
-                                    "physical_device": {
-                                        "category": {
-                                            "hardware_inventory": {
-                                                "tier": "supplemental",
-                                                "confidence": "high",
-                                                "mode": "replace",
+                    "source": [
+                        {
+                            "vmware": {
+                                "api_type": "vmware",
+                                "authority": [
+                                    {
+                                        "scope": [
+                                            {
+                                                "physical_device": {
+                                                    "category": [
+                                                        {
+                                                            "hardware_inventory": {
+                                                                "tier": "supplemental",
+                                                                "confidence": "high",
+                                                                "mode": "replace",
+                                                            }
+                                                        }
+                                                    ]
+                                                }
                                             }
-                                        }
+                                        ]
                                     }
-                                }
-                            },
+                                ],
+                            }
                         }
-                    }
+                    ]
                 }
             )
 
     def test_parse_hcl_document_rejects_non_list_sections(self) -> None:
-        with self.assertRaisesRegex(HclConfigError, "source blocks must be a mapping"):
-            parse_hcl_document({"source": []})
+        with self.assertRaisesRegex(HclConfigError, "source blocks must be a list"):
+            parse_hcl_document({"source": {}})
 
     def test_parse_hcl_document_rejects_empty_block_name(self) -> None:
         with self.assertRaisesRegex(HclConfigError, "source block names must be non-empty strings"):
-            parse_hcl_document({"source": {"": {"api_type": "vmware"}}})
+            parse_hcl_document({"source": [{"": {"api_type": "vmware"}}]})
 
-    def test_parse_hcl_document_rejects_non_mapping_document(self) -> None:
-        with self.assertRaisesRegex(HclConfigError, "HCL document input must be a mapping"):
-            parse_hcl_document([])  # type: ignore[arg-type]
+    def test_parse_hcl_text_rejects_empty_text(self) -> None:
+        with self.assertRaisesRegex(HclConfigError, "HCL text input must be non-empty"):
+            parse_hcl_text("")
 
 
 if __name__ == "__main__":

--- a/tests/test_hcl_parser.py
+++ b/tests/test_hcl_parser.py
@@ -40,7 +40,7 @@ class HclParserTests(unittest.TestCase):
                     "campus-defaults": {
                         "classify": {
                             "location": {
-                                "attributes": {"site_map": "regex/site_map"},
+                                "site_map": "regex/site_map",
                             }
                         }
                     }
@@ -74,6 +74,7 @@ class HclParserTests(unittest.TestCase):
         self.assertEqual(authority_field.name, "serial")
         self.assertEqual(authority_field.rule.confidence, None)
         self.assertEqual(policy.classifications[0].target, NodeScope.LOCATION)
+        self.assertEqual(policy.classifications[0].attributes["site_map"], "regex/site_map")
         self.assertEqual(projection.include_scopes, (NodeScope.PHYSICAL_DEVICE, NodeScope.PORT))
         self.assertEqual(projection.scopes[1].scope, NodeScope.PORT)
 


### PR DESCRIPTION
## Summary
- add the first minimal parser contract for HCL-like configuration input
- parse source, authority, policy, and projection mappings into the typed config dataclasses
- add validation tests for valid minimal input and malformed document shapes

## Validation
- `docker compose build app`
- `docker compose run --rm app sh -lc "export PATH=/opt/poetry/bin:$PATH && poetry install --with dev && poetry run ruff format --check . && poetry run ruff check . && PYTHONPATH=src poetry run pytest"`

Closes #6