### PR TITLE
feat: add control-plane runtime models

### DIFF
--- a/src/canonical_discovery/control_plane/__init__.py
+++ b/src/canonical_discovery/control_plane/__init__.py
@@ -1,0 +1,23 @@
+"""Control-plane runtime models."""
+
+from canonical_discovery.control_plane.models import (
+    Heartbeat,
+    Job,
+    Lease,
+    Result,
+    Run,
+    Task,
+)
+from canonical_discovery.control_plane.status import JobStatus, RunStatus, TaskStatus
+
+__all__ = [
+    "Heartbeat",
+    "Job",
+    "JobStatus",
+    "Lease",
+    "Result",
+    "Run",
+    "RunStatus",
+    "Task",
+    "TaskStatus",
+]

--- a/src/canonical_discovery/control_plane/models.py
+++ b/src/canonical_discovery/control_plane/models.py
@@ -1,0 +1,125 @@
+"""Control-plane dataclass models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from canonical_discovery.control_plane.status import JobStatus, RunStatus, TaskStatus
+
+
+@dataclass(frozen=True, slots=True)
+class Run:
+    run_id: str
+    created_at: datetime
+    trigger_type: str
+    requested_mode: str
+    status: RunStatus
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "created_at": self.created_at.isoformat(),
+            "trigger_type": self.trigger_type,
+            "requested_mode": self.requested_mode,
+            "status": self.status.value,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class Job:
+    job_id: str
+    run_id: str
+    job_kind: str
+    service_role: str
+    required_tags: tuple[str, ...] = ()
+    priority: int = 0
+    status: JobStatus = JobStatus.PENDING
+    attempt_count: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "job_id": self.job_id,
+            "run_id": self.run_id,
+            "job_kind": self.job_kind,
+            "service_role": self.service_role,
+            "required_tags": list(self.required_tags),
+            "priority": self.priority,
+            "status": self.status.value,
+            "attempt_count": self.attempt_count,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class Task:
+    task_id: str
+    job_id: str
+    task_kind: str
+    status: TaskStatus = TaskStatus.PENDING
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "job_id": self.job_id,
+            "task_kind": self.task_kind,
+            "status": self.status.value,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class Lease:
+    lease_id: str
+    job_id: str
+    claimant_id: str
+    issued_at: datetime
+    expires_at: datetime
+    last_heartbeat_at: datetime | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "lease_id": self.lease_id,
+            "job_id": self.job_id,
+            "claimant_id": self.claimant_id,
+            "issued_at": self.issued_at.isoformat(),
+            "expires_at": self.expires_at.isoformat(),
+            "last_heartbeat_at": self.last_heartbeat_at.isoformat()
+            if self.last_heartbeat_at is not None
+            else None,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class Heartbeat:
+    lease_id: str
+    observed_at: datetime
+    status: str
+    progress: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "lease_id": self.lease_id,
+            "observed_at": self.observed_at.isoformat(),
+            "status": self.status,
+            "progress": self.progress,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class Result:
+    result_id: str
+    job_id: str
+    status: str
+    summary: str
+    metrics: dict[str, int | float] = field(default_factory=dict)
+    artifact_refs: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "result_id": self.result_id,
+            "job_id": self.job_id,
+            "status": self.status,
+            "summary": self.summary,
+            "metrics": dict(self.metrics),
+            "artifact_refs": list(self.artifact_refs),
+        }

--- a/src/canonical_discovery/control_plane/status.py
+++ b/src/canonical_discovery/control_plane/status.py
@@ -1,0 +1,33 @@
+"""Status enums for control-plane runtime models."""
+
+from enum import StrEnum
+
+
+class RunStatus(StrEnum):
+    PENDING = "pending"
+    QUEUED = "queued"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    PARTIAL = "partial"
+    CANCELLED = "cancelled"
+
+
+class JobStatus(StrEnum):
+    PENDING = "pending"
+    QUEUED = "queued"
+    CLAIMED = "claimed"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    EXPIRED = "expired"
+    CANCELLED = "cancelled"
+
+
+class TaskStatus(StrEnum):
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+    CANCELLED = "cancelled"

--- a/tests/test_control_plane_models.py
+++ b/tests/test_control_plane_models.py
@@ -1,0 +1,113 @@
+"""Tests for control-plane runtime models."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime
+
+from canonical_discovery.control_plane import (
+    Heartbeat,
+    Job,
+    JobStatus,
+    Lease,
+    Result,
+    Run,
+    RunStatus,
+    Task,
+    TaskStatus,
+)
+
+
+class RunTests(unittest.TestCase):
+    def test_run_to_dict_uses_status_value_and_iso_timestamp(self) -> None:
+        run = Run(
+            run_id="run-1",
+            created_at=datetime(2026, 4, 30, 12, 0, 0),
+            trigger_type="manual",
+            requested_mode="discovery_only",
+            status=RunStatus.QUEUED,
+        )
+
+        self.assertEqual(
+            run.to_dict(),
+            {
+                "run_id": "run-1",
+                "created_at": "2026-04-30T12:00:00",
+                "trigger_type": "manual",
+                "requested_mode": "discovery_only",
+                "status": "queued",
+            },
+        )
+
+
+class JobTests(unittest.TestCase):
+    def test_job_defaults_and_serialization(self) -> None:
+        job = Job(
+            job_id="job-1",
+            run_id="run-1",
+            job_kind="collect_source",
+            service_role="collector",
+            required_tags=("vmware",),
+            priority=5,
+            status=JobStatus.CLAIMED,
+            attempt_count=1,
+        )
+
+        self.assertEqual(job.to_dict()["status"], "claimed")
+        self.assertEqual(job.to_dict()["required_tags"], ["vmware"])
+        self.assertEqual(job.to_dict()["attempt_count"], 1)
+
+
+class TaskTests(unittest.TestCase):
+    def test_task_serialization_uses_status_value(self) -> None:
+        task = Task(
+            task_id="task-1", job_id="job-1", task_kind="adapter", status=TaskStatus.RUNNING
+        )
+
+        self.assertEqual(task.to_dict()["status"], "running")
+
+
+class LeaseTests(unittest.TestCase):
+    def test_lease_serialization_handles_optional_heartbeat(self) -> None:
+        lease = Lease(
+            lease_id="lease-1",
+            job_id="job-1",
+            claimant_id="collector-a",
+            issued_at=datetime(2026, 4, 30, 12, 0, 0),
+            expires_at=datetime(2026, 4, 30, 12, 5, 0),
+        )
+
+        self.assertIsNone(lease.to_dict()["last_heartbeat_at"])
+
+
+class HeartbeatTests(unittest.TestCase):
+    def test_heartbeat_serialization_preserves_progress(self) -> None:
+        heartbeat = Heartbeat(
+            lease_id="lease-1",
+            observed_at=datetime(2026, 4, 30, 12, 1, 0),
+            status="running",
+            progress="50%",
+        )
+
+        self.assertEqual(heartbeat.to_dict()["progress"], "50%")
+
+
+class ResultTests(unittest.TestCase):
+    def test_result_serialization_copies_metrics_and_artifacts(self) -> None:
+        result = Result(
+            result_id="result-1",
+            job_id="job-1",
+            status="succeeded",
+            summary="collector finished",
+            metrics={"nodes": 4, "duration_seconds": 1.5},
+            artifact_refs=("artifact-1",),
+        )
+
+        serialized = result.to_dict()
+
+        self.assertEqual(serialized["metrics"], {"nodes": 4, "duration_seconds": 1.5})
+        self.assertEqual(serialized["artifact_refs"], ["artifact-1"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add the first control-plane status enums and runtime dataclasses for run, job, task, lease, heartbeat, and result
- keep control-plane state isolated from canonical graph state in a dedicated `control_plane` package
- add serialization and tests for the initial runtime model layer from RFC 0005

## Validation
- `docker compose build app`
- `docker compose run --rm app sh -lc "export PATH=/opt/poetry/bin:$PATH && poetry install --with dev && poetry run ruff format --check . && poetry run ruff check . && PYTHONPATH=src poetry run pytest"`

Closes #22