### PR TITLE
feat: add control-plane repositories

### DIFF
--- a/src/canonical_discovery/repository/__init__.py
+++ b/src/canonical_discovery/repository/__init__.py
@@ -1,0 +1,6 @@
+"""Repository abstractions and implementations."""
+
+from canonical_discovery.repository.control_plane import ControlPlaneRepository
+from canonical_discovery.repository.sqlite_control_plane import SQLiteControlPlaneRepository
+
+__all__ = ["ControlPlaneRepository", "SQLiteControlPlaneRepository"]

--- a/src/canonical_discovery/repository/control_plane.py
+++ b/src/canonical_discovery/repository/control_plane.py
@@ -1,0 +1,43 @@
+"""Repository protocol for control-plane persistence."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from canonical_discovery.control_plane import Job, Lease, Result, Run
+
+
+class ControlPlaneRepository(ABC):
+    """Persistence interface for control-plane runtime records."""
+
+    @abstractmethod
+    def save_run(self, run: Run) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_run(self, run_id: str) -> Run | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def save_job(self, job: Job) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_job(self, job_id: str) -> Job | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def save_lease(self, lease: Lease) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_lease(self, lease_id: str) -> Lease | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def save_result(self, result: Result) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_result(self, result_id: str) -> Result | None:
+        raise NotImplementedError

--- a/src/canonical_discovery/repository/sqlite_control_plane.py
+++ b/src/canonical_discovery/repository/sqlite_control_plane.py
@@ -19,6 +19,8 @@ class SQLiteControlPlaneRepository(ControlPlaneRepository):
         self._shared_connection = (
             sqlite3.connect(self._database_path) if self._database_path == ":memory:" else None
         )
+        if self._shared_connection is not None:
+            self._shared_connection.execute("PRAGMA foreign_keys = ON")
         self._initialize_schema()
 
     def save_run(self, run: Run) -> None:
@@ -212,7 +214,7 @@ class SQLiteControlPlaneRepository(ControlPlaneRepository):
 
                 CREATE TABLE IF NOT EXISTS jobs (
                     job_id TEXT PRIMARY KEY,
-                    run_id TEXT NOT NULL,
+                    run_id TEXT NOT NULL REFERENCES runs(run_id),
                     job_kind TEXT NOT NULL,
                     service_role TEXT NOT NULL,
                     required_tags TEXT NOT NULL,
@@ -223,7 +225,7 @@ class SQLiteControlPlaneRepository(ControlPlaneRepository):
 
                 CREATE TABLE IF NOT EXISTS leases (
                     lease_id TEXT PRIMARY KEY,
-                    job_id TEXT NOT NULL,
+                    job_id TEXT NOT NULL REFERENCES jobs(job_id),
                     claimant_id TEXT NOT NULL,
                     issued_at TEXT NOT NULL,
                     expires_at TEXT NOT NULL,
@@ -232,7 +234,7 @@ class SQLiteControlPlaneRepository(ControlPlaneRepository):
 
                 CREATE TABLE IF NOT EXISTS results (
                     result_id TEXT PRIMARY KEY,
-                    job_id TEXT NOT NULL,
+                    job_id TEXT NOT NULL REFERENCES jobs(job_id),
                     status TEXT NOT NULL,
                     summary TEXT NOT NULL,
                     metrics TEXT NOT NULL,
@@ -253,6 +255,7 @@ class SQLiteControlPlaneRepository(ControlPlaneRepository):
             return
 
         connection = sqlite3.connect(self._database_path)
+        connection.execute("PRAGMA foreign_keys = ON")
         try:
             yield connection
             connection.commit()

--- a/src/canonical_discovery/repository/sqlite_control_plane.py
+++ b/src/canonical_discovery/repository/sqlite_control_plane.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from contextlib import contextmanager
 from datetime import datetime
 
 from canonical_discovery.control_plane import Job, JobStatus, Lease, Result, Run, RunStatus
@@ -15,10 +16,13 @@ class SQLiteControlPlaneRepository(ControlPlaneRepository):
 
     def __init__(self, database_path: str) -> None:
         self._database_path = database_path
+        self._shared_connection = (
+            sqlite3.connect(self._database_path) if self._database_path == ":memory:" else None
+        )
         self._initialize_schema()
 
     def save_run(self, run: Run) -> None:
-        with self._connect() as connection:
+        with self._connection() as connection:
             connection.execute(
                 """
                 INSERT OR REPLACE INTO runs (
@@ -59,7 +63,7 @@ class SQLiteControlPlaneRepository(ControlPlaneRepository):
         )
 
     def save_job(self, job: Job) -> None:
-        with self._connect() as connection:
+        with self._connection() as connection:
             connection.execute(
                 """
                 INSERT OR REPLACE INTO jobs (
@@ -109,7 +113,7 @@ class SQLiteControlPlaneRepository(ControlPlaneRepository):
         )
 
     def save_lease(self, lease: Lease) -> None:
-        with self._connect() as connection:
+        with self._connection() as connection:
             connection.execute(
                 """
                 INSERT OR REPLACE INTO leases (
@@ -152,7 +156,7 @@ class SQLiteControlPlaneRepository(ControlPlaneRepository):
         )
 
     def save_result(self, result: Result) -> None:
-        with self._connect() as connection:
+        with self._connection() as connection:
             connection.execute(
                 """
                 INSERT OR REPLACE INTO results (
@@ -195,7 +199,7 @@ class SQLiteControlPlaneRepository(ControlPlaneRepository):
         )
 
     def _initialize_schema(self) -> None:
-        with self._connect() as connection:
+        with self._connection() as connection:
             connection.executescript(
                 """
                 CREATE TABLE IF NOT EXISTS runs (
@@ -237,10 +241,28 @@ class SQLiteControlPlaneRepository(ControlPlaneRepository):
                 """
             )
 
-    def _connect(self) -> sqlite3.Connection:
-        return sqlite3.connect(self._database_path)
+    @contextmanager
+    def _connection(self):
+        if self._shared_connection is not None:
+            try:
+                yield self._shared_connection
+                self._shared_connection.commit()
+            except Exception:
+                self._shared_connection.rollback()
+                raise
+            return
+
+        connection = sqlite3.connect(self._database_path)
+        try:
+            yield connection
+            connection.commit()
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
 
     def _fetch_one(self, query: str, params: tuple[str, ...]) -> tuple | None:
-        with self._connect() as connection:
+        with self._connection() as connection:
             row = connection.execute(query, params).fetchone()
         return row

--- a/src/canonical_discovery/repository/sqlite_control_plane.py
+++ b/src/canonical_discovery/repository/sqlite_control_plane.py
@@ -1,0 +1,246 @@
+"""SQLite-backed control-plane repository implementation."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime
+
+from canonical_discovery.control_plane import Job, JobStatus, Lease, Result, Run, RunStatus
+from canonical_discovery.repository.control_plane import ControlPlaneRepository
+
+
+class SQLiteControlPlaneRepository(ControlPlaneRepository):
+    """SQLite-backed persistence for control-plane runtime records."""
+
+    def __init__(self, database_path: str) -> None:
+        self._database_path = database_path
+        self._initialize_schema()
+
+    def save_run(self, run: Run) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                INSERT OR REPLACE INTO runs (
+                    run_id,
+                    created_at,
+                    trigger_type,
+                    requested_mode,
+                    status
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    run.run_id,
+                    run.created_at.isoformat(),
+                    run.trigger_type,
+                    run.requested_mode,
+                    run.status.value,
+                ),
+            )
+
+    def get_run(self, run_id: str) -> Run | None:
+        row = self._fetch_one(
+            """
+            SELECT run_id, created_at, trigger_type, requested_mode, status
+            FROM runs
+            WHERE run_id = ?
+            """,
+            (run_id,),
+        )
+        if row is None:
+            return None
+
+        return Run(
+            run_id=row[0],
+            created_at=datetime.fromisoformat(row[1]),
+            trigger_type=row[2],
+            requested_mode=row[3],
+            status=RunStatus(row[4]),
+        )
+
+    def save_job(self, job: Job) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                INSERT OR REPLACE INTO jobs (
+                    job_id,
+                    run_id,
+                    job_kind,
+                    service_role,
+                    required_tags,
+                    priority,
+                    status,
+                    attempt_count
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    job.job_id,
+                    job.run_id,
+                    job.job_kind,
+                    job.service_role,
+                    json.dumps(list(job.required_tags)),
+                    job.priority,
+                    job.status.value,
+                    job.attempt_count,
+                ),
+            )
+
+    def get_job(self, job_id: str) -> Job | None:
+        row = self._fetch_one(
+            """
+            SELECT job_id, run_id, job_kind, service_role, required_tags,
+                   priority, status, attempt_count
+            FROM jobs WHERE job_id = ?
+            """,
+            (job_id,),
+        )
+        if row is None:
+            return None
+
+        return Job(
+            job_id=row[0],
+            run_id=row[1],
+            job_kind=row[2],
+            service_role=row[3],
+            required_tags=tuple(json.loads(row[4])),
+            priority=row[5],
+            status=JobStatus(row[6]),
+            attempt_count=row[7],
+        )
+
+    def save_lease(self, lease: Lease) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                INSERT OR REPLACE INTO leases (
+                    lease_id,
+                    job_id,
+                    claimant_id,
+                    issued_at,
+                    expires_at,
+                    last_heartbeat_at
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    lease.lease_id,
+                    lease.job_id,
+                    lease.claimant_id,
+                    lease.issued_at.isoformat(),
+                    lease.expires_at.isoformat(),
+                    lease.last_heartbeat_at.isoformat() if lease.last_heartbeat_at else None,
+                ),
+            )
+
+    def get_lease(self, lease_id: str) -> Lease | None:
+        row = self._fetch_one(
+            """
+            SELECT lease_id, job_id, claimant_id, issued_at, expires_at, last_heartbeat_at
+            FROM leases WHERE lease_id = ?
+            """,
+            (lease_id,),
+        )
+        if row is None:
+            return None
+
+        return Lease(
+            lease_id=row[0],
+            job_id=row[1],
+            claimant_id=row[2],
+            issued_at=datetime.fromisoformat(row[3]),
+            expires_at=datetime.fromisoformat(row[4]),
+            last_heartbeat_at=datetime.fromisoformat(row[5]) if row[5] is not None else None,
+        )
+
+    def save_result(self, result: Result) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                INSERT OR REPLACE INTO results (
+                    result_id,
+                    job_id,
+                    status,
+                    summary,
+                    metrics,
+                    artifact_refs
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    result.result_id,
+                    result.job_id,
+                    result.status,
+                    result.summary,
+                    json.dumps(result.metrics),
+                    json.dumps(list(result.artifact_refs)),
+                ),
+            )
+
+    def get_result(self, result_id: str) -> Result | None:
+        row = self._fetch_one(
+            """
+            SELECT result_id, job_id, status, summary, metrics, artifact_refs
+            FROM results WHERE result_id = ?
+            """,
+            (result_id,),
+        )
+        if row is None:
+            return None
+
+        return Result(
+            result_id=row[0],
+            job_id=row[1],
+            status=row[2],
+            summary=row[3],
+            metrics=json.loads(row[4]),
+            artifact_refs=tuple(json.loads(row[5])),
+        )
+
+    def _initialize_schema(self) -> None:
+        with self._connect() as connection:
+            connection.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS runs (
+                    run_id TEXT PRIMARY KEY,
+                    created_at TEXT NOT NULL,
+                    trigger_type TEXT NOT NULL,
+                    requested_mode TEXT NOT NULL,
+                    status TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS jobs (
+                    job_id TEXT PRIMARY KEY,
+                    run_id TEXT NOT NULL,
+                    job_kind TEXT NOT NULL,
+                    service_role TEXT NOT NULL,
+                    required_tags TEXT NOT NULL,
+                    priority INTEGER NOT NULL,
+                    status TEXT NOT NULL,
+                    attempt_count INTEGER NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS leases (
+                    lease_id TEXT PRIMARY KEY,
+                    job_id TEXT NOT NULL,
+                    claimant_id TEXT NOT NULL,
+                    issued_at TEXT NOT NULL,
+                    expires_at TEXT NOT NULL,
+                    last_heartbeat_at TEXT
+                );
+
+                CREATE TABLE IF NOT EXISTS results (
+                    result_id TEXT PRIMARY KEY,
+                    job_id TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    summary TEXT NOT NULL,
+                    metrics TEXT NOT NULL,
+                    artifact_refs TEXT NOT NULL
+                );
+                """
+            )
+
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(self._database_path)
+
+    def _fetch_one(self, query: str, params: tuple[str, ...]) -> tuple | None:
+        with self._connect() as connection:
+            row = connection.execute(query, params).fetchone()
+        return row

--- a/tests/test_sqlite_control_plane_repository.py
+++ b/tests/test_sqlite_control_plane_repository.py
@@ -1,0 +1,72 @@
+"""Tests for the SQLite-backed control-plane repository."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from datetime import datetime
+
+from canonical_discovery.control_plane import Job, JobStatus, Lease, Result, Run, RunStatus
+from canonical_discovery.repository import SQLiteControlPlaneRepository
+
+
+class SQLiteControlPlaneRepositoryTests(unittest.TestCase):
+    def test_round_trip_run_job_lease_and_result(self) -> None:
+        with tempfile.NamedTemporaryFile() as temp_db:
+            repository = SQLiteControlPlaneRepository(temp_db.name)
+
+            run = Run(
+                run_id="run-1",
+                created_at=datetime(2026, 4, 30, 12, 0, 0),
+                trigger_type="manual",
+                requested_mode="discovery_only",
+                status=RunStatus.QUEUED,
+            )
+            job = Job(
+                job_id="job-1",
+                run_id="run-1",
+                job_kind="collect_source",
+                service_role="collector",
+                required_tags=("vmware",),
+                priority=5,
+                status=JobStatus.CLAIMED,
+                attempt_count=1,
+            )
+            lease = Lease(
+                lease_id="lease-1",
+                job_id="job-1",
+                claimant_id="collector-a",
+                issued_at=datetime(2026, 4, 30, 12, 0, 0),
+                expires_at=datetime(2026, 4, 30, 12, 5, 0),
+            )
+            result = Result(
+                result_id="result-1",
+                job_id="job-1",
+                status="succeeded",
+                summary="collector finished",
+                metrics={"nodes": 4, "duration_seconds": 1.5},
+                artifact_refs=("artifact-1",),
+            )
+
+            repository.save_run(run)
+            repository.save_job(job)
+            repository.save_lease(lease)
+            repository.save_result(result)
+
+            self.assertEqual(repository.get_run("run-1"), run)
+            self.assertEqual(repository.get_job("job-1"), job)
+            self.assertEqual(repository.get_lease("lease-1"), lease)
+            self.assertEqual(repository.get_result("result-1"), result)
+
+    def test_missing_records_return_none(self) -> None:
+        with tempfile.NamedTemporaryFile() as temp_db:
+            repository = SQLiteControlPlaneRepository(temp_db.name)
+
+            self.assertIsNone(repository.get_run("missing"))
+            self.assertIsNone(repository.get_job("missing"))
+            self.assertIsNone(repository.get_lease("missing"))
+            self.assertIsNone(repository.get_result("missing"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sqlite_control_plane_repository.py
+++ b/tests/test_sqlite_control_plane_repository.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 import tempfile
 import unittest
 from datetime import datetime
@@ -66,6 +67,64 @@ class SQLiteControlPlaneRepositoryTests(unittest.TestCase):
             self.assertIsNone(repository.get_job("missing"))
             self.assertIsNone(repository.get_lease("missing"))
             self.assertIsNone(repository.get_result("missing"))
+
+    def test_in_memory_database_supports_round_trip(self) -> None:
+        repository = SQLiteControlPlaneRepository(":memory:")
+
+        run = Run(
+            run_id="run-1",
+            created_at=datetime(2026, 4, 30, 12, 0, 0),
+            trigger_type="manual",
+            requested_mode="discovery_only",
+            status=RunStatus.QUEUED,
+        )
+
+        repository.save_run(run)
+
+        self.assertEqual(repository.get_run("run-1"), run)
+
+    def test_job_requires_existing_run(self) -> None:
+        with tempfile.NamedTemporaryFile() as temp_db:
+            repository = SQLiteControlPlaneRepository(temp_db.name)
+
+            job = Job(
+                job_id="job-1",
+                run_id="missing-run",
+                job_kind="collect_source",
+                service_role="collector",
+            )
+
+            with self.assertRaises(sqlite3.IntegrityError):
+                repository.save_job(job)
+
+    def test_lease_requires_existing_job(self) -> None:
+        with tempfile.NamedTemporaryFile() as temp_db:
+            repository = SQLiteControlPlaneRepository(temp_db.name)
+
+            lease = Lease(
+                lease_id="lease-1",
+                job_id="missing-job",
+                claimant_id="collector-a",
+                issued_at=datetime(2026, 4, 30, 12, 0, 0),
+                expires_at=datetime(2026, 4, 30, 12, 5, 0),
+            )
+
+            with self.assertRaises(sqlite3.IntegrityError):
+                repository.save_lease(lease)
+
+    def test_result_requires_existing_job(self) -> None:
+        with tempfile.NamedTemporaryFile() as temp_db:
+            repository = SQLiteControlPlaneRepository(temp_db.name)
+
+            result = Result(
+                result_id="result-1",
+                job_id="missing-job",
+                status="succeeded",
+                summary="collector finished",
+            )
+
+            with self.assertRaises(sqlite3.IntegrityError):
+                repository.save_result(result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add the first repository abstraction for control-plane persistence
- implement a SQLite-backed control-plane repository for runs, jobs, leases, and results
- add repository round-trip tests for the new persistence layer

## Validation
- `docker compose build app`
- `docker compose run --rm app sh -lc "export PATH=/opt/poetry/bin:$PATH && poetry install --with dev && poetry run ruff format --check . && poetry run ruff check . && PYTHONPATH=src poetry run pytest"`

Closes #23