### PR TITLE
feat: add collector lifecycle API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,5 +39,3 @@ RUN mkdir -p /var/lib/canonical-discovery
 ENV PYTHONPATH=/workspace/src
 
 CMD ["sh", "-lc", "export PATH=/opt/poetry/bin:$PATH && poetry run gunicorn -k uvicorn.workers.UvicornWorker canonical_discovery.api:app --bind 0.0.0.0:8000"]
-
-CMD ["gunicorn", "-k", "uvicorn.workers.UvicornWorker", "canonical_discovery.api:app", "--bind", "0.0.0.0:8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,12 +28,16 @@ FROM base AS dev
 
 RUN poetry install --no-root --with dev
 
-CMD ["sleep", "infinity"]
-
 FROM base AS runtime
 
 WORKDIR /workspace
 
 COPY . /workspace
+
+RUN mkdir -p /var/lib/canonical-discovery
+
+ENV PYTHONPATH=/workspace/src
+
+CMD ["sh", "-lc", "export PATH=/opt/poetry/bin:$PATH && poetry run gunicorn -k uvicorn.workers.UvicornWorker canonical_discovery.api:app --bind 0.0.0.0:8000"]
 
 CMD ["gunicorn", "-k", "uvicorn.workers.UvicornWorker", "canonical_discovery.api:app", "--bind", "0.0.0.0:8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,3 +35,5 @@ FROM base AS runtime
 WORKDIR /workspace
 
 COPY . /workspace
+
+CMD ["gunicorn", "-k", "uvicorn.workers.UvicornWorker", "canonical_discovery.api:app", "--bind", "0.0.0.0:8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,8 @@ services:
       target: runtime
     image: ${CANONICAL_DISCOVERY_APP_IMAGE:-ghcr.io/clemson-netbox/canonical-discovery}:${CANONICAL_DISCOVERY_IMAGE_TAG:-dev}
     working_dir: /workspace
-    command: ["python", "--version"]
+    ports:
+      - "8000:8000"
 
   devcontainer:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,10 @@ services:
     working_dir: /workspace
     ports:
       - "8000:8000"
+    environment:
+      CANONICAL_DISCOVERY_DB_PATH: /var/lib/canonical-discovery/control-plane.db
+    volumes:
+      - app-data:/var/lib/canonical-discovery
 
   devcontainer:
     build:
@@ -22,4 +26,5 @@ services:
       - poetry-venvs:/opt/poetry-venvs
 
 volumes:
+  app-data:
   poetry-venvs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,14 @@ readme = "README.md"
 package-mode = false
 
 [tool.poetry.dependencies]
+fastapi = "^0.116.1"
+gunicorn = "^23.0.0"
 python-hcl2 = "^7.3.1"
 python = "^3.12"
+uvicorn = "^0.35.0"
 
 [tool.poetry.group.dev.dependencies]
+httpx = "^0.28.1"
 pytest = ">=8,<9"
 ruff = ">=0.6,<1.0"
 

--- a/src/canonical_discovery/api/__init__.py
+++ b/src/canonical_discovery/api/__init__.py
@@ -1,0 +1,5 @@
+"""API application package."""
+
+from canonical_discovery.api.app import app, create_app
+
+__all__ = ["app", "create_app"]

--- a/src/canonical_discovery/api/app.py
+++ b/src/canonical_discovery/api/app.py
@@ -14,7 +14,6 @@ from pydantic import BaseModel, Field
 from canonical_discovery.control_plane import (
     CollectorSession,
     GraphSubmission,
-    Job,
     JobStatus,
     Lease,
     Result,
@@ -181,6 +180,9 @@ def create_app(repository: ControlPlaneRepository) -> FastAPI:
             raise HTTPException(status_code=403, detail="lease claimant mismatch")
         if lease.expires_at <= datetime.now(UTC):
             raise HTTPException(status_code=409, detail="lease expired")
+        job = repository.get_job(lease.job_id)
+        if job is None or job.status not in {JobStatus.CLAIMED, JobStatus.RUNNING}:
+            raise HTTPException(status_code=409, detail="job is not active for heartbeat")
 
         updated_lease = Lease(
             lease_id=lease.lease_id,
@@ -207,6 +209,9 @@ def create_app(repository: ControlPlaneRepository) -> FastAPI:
             raise HTTPException(status_code=403, detail="lease claimant mismatch")
         if lease.expires_at <= datetime.now(UTC):
             raise HTTPException(status_code=409, detail="lease expired")
+        job = repository.get_job(lease.job_id)
+        if job is None or job.status not in {JobStatus.CLAIMED, JobStatus.RUNNING}:
+            raise HTTPException(status_code=409, detail="job is not active for graph submission")
 
         submission = repository.get_graph_submission_for_lease(request.lease_id) or GraphSubmission(
             submission_id=request.lease_id,
@@ -257,19 +262,16 @@ def create_app(repository: ControlPlaneRepository) -> FastAPI:
             metrics=dict(request.metrics),
             artifact_refs=tuple(request.artifact_refs),
         )
-        repository.save_result(result)
-        repository.save_job(
-            Job(
-                job_id=job.job_id,
-                run_id=job.run_id,
-                job_kind=job.job_kind,
-                service_role=job.service_role,
-                required_tags=job.required_tags,
-                priority=job.priority,
-                status=next_status,
-                attempt_count=job.attempt_count,
-            )
+        finalized = repository.finalize_job_result(
+            job=job,
+            lease_id=request.lease_id,
+            result=result,
+            next_status=next_status,
         )
+        if not finalized:
+            raise HTTPException(
+                status_code=409, detail="job result could not be finalized atomically"
+            )
 
         return ResultSubmissionResponse(result_id=result.result_id, accepted=True)
 

--- a/src/canonical_discovery/api/app.py
+++ b/src/canonical_discovery/api/app.py
@@ -22,6 +22,7 @@ from canonical_discovery.repository import ControlPlaneRepository, SQLiteControl
 
 LEASE_TTL_SECONDS = 300
 CHECK_IN_INTERVAL_SECONDS = 60
+TERMINAL_JOB_STATUSES = {JobStatus.SUCCEEDED, JobStatus.FAILED, JobStatus.CANCELLED}
 
 
 class CollectorCheckInRequest(BaseModel):
@@ -147,26 +148,15 @@ def create_app(repository: ControlPlaneRepository) -> FastAPI:
 
             issued_at = datetime.now(UTC)
             expires_at = issued_at + timedelta(seconds=LEASE_TTL_SECONDS)
-            lease = Lease(
-                lease_id=str(uuid4()),
+            lease = repository.claim_job(
                 job_id=job.job_id,
                 claimant_id=request.collector_instance_id,
+                lease_id=str(uuid4()),
                 issued_at=issued_at,
                 expires_at=expires_at,
             )
-            repository.save_lease(lease)
-            repository.save_job(
-                Job(
-                    job_id=job.job_id,
-                    run_id=job.run_id,
-                    job_kind=job.job_kind,
-                    service_role=job.service_role,
-                    required_tags=job.required_tags,
-                    priority=job.priority,
-                    status=JobStatus.CLAIMED,
-                    attempt_count=job.attempt_count,
-                )
-            )
+            if lease is None:
+                continue
             claimed_jobs.append(
                 ClaimedJobResponse(
                     job_id=job.job_id,
@@ -248,6 +238,10 @@ def create_app(repository: ControlPlaneRepository) -> FastAPI:
             next_status = JobStatus(request.status)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail="invalid job status") from exc
+        if next_status not in TERMINAL_JOB_STATUSES:
+            raise HTTPException(
+                status_code=400, detail="result submission requires a terminal job status"
+            )
 
         result = Result(
             result_id=str(uuid4()),

--- a/src/canonical_discovery/api/app.py
+++ b/src/canonical_discovery/api/app.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+import os
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import uuid4
@@ -10,32 +10,18 @@ from uuid import uuid4
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
-from canonical_discovery.control_plane import Job, JobStatus, Lease, Result
+from canonical_discovery.control_plane import (
+    CollectorSession,
+    GraphSubmission,
+    Job,
+    JobStatus,
+    Lease,
+    Result,
+)
 from canonical_discovery.repository import ControlPlaneRepository, SQLiteControlPlaneRepository
 
 LEASE_TTL_SECONDS = 300
 CHECK_IN_INTERVAL_SECONDS = 60
-
-
-@dataclass(slots=True)
-class CollectorSession:
-    collector_instance_id: str
-    collector_version: str
-    capability_tags: tuple[str, ...]
-    max_concurrent_jobs: int
-    current_active_load: int
-    last_known_job_ids: tuple[str, ...]
-    placement: dict[str, str] = field(default_factory=dict)
-    last_check_in_at: datetime = field(default_factory=lambda: datetime.now(UTC))
-
-
-@dataclass(slots=True)
-class GraphSubmission:
-    submission_id: str
-    collector_instance_id: str
-    lease_id: str
-    payload: dict[str, Any]
-    submitted_at: datetime
 
 
 class CollectorCheckInRequest(BaseModel):
@@ -117,8 +103,6 @@ class ResultSubmissionResponse(BaseModel):
 def create_app(repository: ControlPlaneRepository) -> FastAPI:
     app = FastAPI(title="canonical-discovery")
     app.state.repository = repository
-    app.state.collector_sessions = {}
-    app.state.graph_submissions = {}
 
     @app.get("/healthz")
     def healthz() -> dict[str, str]:
@@ -126,14 +110,17 @@ def create_app(repository: ControlPlaneRepository) -> FastAPI:
 
     @app.post("/collectors/check-in", response_model=CollectorCheckInResponse)
     def collector_check_in(request: CollectorCheckInRequest) -> CollectorCheckInResponse:
-        app.state.collector_sessions[request.collector_instance_id] = CollectorSession(
-            collector_instance_id=request.collector_instance_id,
-            collector_version=request.collector_version,
-            capability_tags=tuple(request.capability_tags),
-            max_concurrent_jobs=request.max_concurrent_jobs,
-            current_active_load=request.current_active_load,
-            last_known_job_ids=tuple(request.last_known_job_ids),
-            placement=dict(request.placement),
+        repository.save_collector_session(
+            CollectorSession(
+                collector_instance_id=request.collector_instance_id,
+                collector_version=request.collector_version,
+                capability_tags=tuple(request.capability_tags),
+                max_concurrent_jobs=request.max_concurrent_jobs,
+                current_active_load=request.current_active_load,
+                last_known_job_ids=tuple(request.last_known_job_ids),
+                placement=dict(request.placement),
+                last_check_in_at=datetime.now(UTC),
+            )
         )
         return CollectorCheckInResponse(
             collector_instance_id=request.collector_instance_id,
@@ -143,7 +130,7 @@ def create_app(repository: ControlPlaneRepository) -> FastAPI:
 
     @app.post("/collectors/claim-work", response_model=ClaimWorkResponse)
     def claim_work(request: ClaimWorkRequest) -> ClaimWorkResponse:
-        session = app.state.collector_sessions.get(request.collector_instance_id)
+        session = repository.get_collector_session(request.collector_instance_id)
         if session is None:
             raise HTTPException(status_code=404, detail="collector session not found")
 
@@ -198,6 +185,10 @@ def create_app(repository: ControlPlaneRepository) -> FastAPI:
         lease = repository.get_lease(request.lease_id)
         if lease is None:
             raise HTTPException(status_code=404, detail="lease not found")
+        if lease.claimant_id != request.collector_instance_id:
+            raise HTTPException(status_code=403, detail="lease claimant mismatch")
+        if lease.expires_at <= datetime.now(UTC):
+            raise HTTPException(status_code=409, detail="lease expired")
 
         updated_lease = Lease(
             lease_id=lease.lease_id,
@@ -220,6 +211,10 @@ def create_app(repository: ControlPlaneRepository) -> FastAPI:
         lease = repository.get_lease(request.lease_id)
         if lease is None:
             raise HTTPException(status_code=404, detail="lease not found")
+        if lease.claimant_id != request.collector_instance_id:
+            raise HTTPException(status_code=403, detail="lease claimant mismatch")
+        if lease.expires_at <= datetime.now(UTC):
+            raise HTTPException(status_code=409, detail="lease expired")
 
         submission = GraphSubmission(
             submission_id=str(uuid4()),
@@ -228,7 +223,7 @@ def create_app(repository: ControlPlaneRepository) -> FastAPI:
             payload=dict(request.payload),
             submitted_at=datetime.now(UTC),
         )
-        app.state.graph_submissions[submission.submission_id] = submission
+        repository.save_graph_submission(submission)
 
         return GraphSubmissionResponse(submission_id=submission.submission_id, accepted=True)
 
@@ -237,6 +232,22 @@ def create_app(repository: ControlPlaneRepository) -> FastAPI:
         job = repository.get_job(request.job_id)
         if job is None:
             raise HTTPException(status_code=404, detail="job not found")
+        lease = repository.get_lease_for_job(request.job_id)
+        if lease is None:
+            raise HTTPException(status_code=409, detail="active lease not found for job")
+        if lease.claimant_id != request.collector_instance_id:
+            raise HTTPException(status_code=403, detail="lease claimant mismatch")
+        if lease.expires_at <= datetime.now(UTC):
+            raise HTTPException(status_code=409, detail="lease expired")
+        if job.status not in {JobStatus.CLAIMED, JobStatus.RUNNING}:
+            raise HTTPException(
+                status_code=409, detail="job is not claimable for terminal result submission"
+            )
+
+        try:
+            next_status = JobStatus(request.status)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail="invalid job status") from exc
 
         result = Result(
             result_id=str(uuid4()),
@@ -255,7 +266,7 @@ def create_app(repository: ControlPlaneRepository) -> FastAPI:
                 service_role=job.service_role,
                 required_tags=job.required_tags,
                 priority=job.priority,
-                status=JobStatus(request.status),
+                status=next_status,
                 attempt_count=job.attempt_count,
             )
         )
@@ -265,4 +276,8 @@ def create_app(repository: ControlPlaneRepository) -> FastAPI:
     return app
 
 
-app = create_app(SQLiteControlPlaneRepository(":memory:"))
+DEFAULT_DB_PATH = os.environ.get(
+    "CANONICAL_DISCOVERY_DB_PATH", "/var/lib/canonical-discovery/control-plane.db"
+)
+
+app = create_app(SQLiteControlPlaneRepository(DEFAULT_DB_PATH))

--- a/src/canonical_discovery/api/app.py
+++ b/src/canonical_discovery/api/app.py
@@ -90,6 +90,7 @@ class GraphSubmissionResponse(BaseModel):
 
 class ResultSubmissionRequest(BaseModel):
     collector_instance_id: str
+    lease_id: str
     job_id: str
     status: str
     summary: str
@@ -207,8 +208,8 @@ def create_app(repository: ControlPlaneRepository) -> FastAPI:
         if lease.expires_at <= datetime.now(UTC):
             raise HTTPException(status_code=409, detail="lease expired")
 
-        submission = GraphSubmission(
-            submission_id=str(uuid4()),
+        submission = repository.get_graph_submission_for_lease(request.lease_id) or GraphSubmission(
+            submission_id=request.lease_id,
             collector_instance_id=request.collector_instance_id,
             lease_id=request.lease_id,
             payload=dict(request.payload),
@@ -223,9 +224,13 @@ def create_app(repository: ControlPlaneRepository) -> FastAPI:
         job = repository.get_job(request.job_id)
         if job is None:
             raise HTTPException(status_code=404, detail="job not found")
-        lease = repository.get_lease_for_job(request.job_id)
+        lease = repository.get_lease(request.lease_id)
         if lease is None:
             raise HTTPException(status_code=409, detail="active lease not found for job")
+        if lease.job_id != request.job_id:
+            raise HTTPException(
+                status_code=409, detail="lease does not belong to the requested job"
+            )
         if lease.claimant_id != request.collector_instance_id:
             raise HTTPException(status_code=403, detail="lease claimant mismatch")
         if lease.expires_at <= datetime.now(UTC):

--- a/src/canonical_discovery/api/app.py
+++ b/src/canonical_discovery/api/app.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
@@ -271,7 +272,9 @@ def create_app(repository: ControlPlaneRepository) -> FastAPI:
 
 
 DEFAULT_DB_PATH = os.environ.get(
-    "CANONICAL_DISCOVERY_DB_PATH", "/var/lib/canonical-discovery/control-plane.db"
+    "CANONICAL_DISCOVERY_DB_PATH", "/workspace/.runtime/control-plane.db"
 )
+
+Path(DEFAULT_DB_PATH).parent.mkdir(parents=True, exist_ok=True)
 
 app = create_app(SQLiteControlPlaneRepository(DEFAULT_DB_PATH))

--- a/src/canonical_discovery/api/app.py
+++ b/src/canonical_discovery/api/app.py
@@ -1,0 +1,268 @@
+"""Minimal collector lifecycle API application."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import uuid4
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from canonical_discovery.control_plane import Job, JobStatus, Lease, Result
+from canonical_discovery.repository import ControlPlaneRepository, SQLiteControlPlaneRepository
+
+LEASE_TTL_SECONDS = 300
+CHECK_IN_INTERVAL_SECONDS = 60
+
+
+@dataclass(slots=True)
+class CollectorSession:
+    collector_instance_id: str
+    collector_version: str
+    capability_tags: tuple[str, ...]
+    max_concurrent_jobs: int
+    current_active_load: int
+    last_known_job_ids: tuple[str, ...]
+    placement: dict[str, str] = field(default_factory=dict)
+    last_check_in_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+
+@dataclass(slots=True)
+class GraphSubmission:
+    submission_id: str
+    collector_instance_id: str
+    lease_id: str
+    payload: dict[str, Any]
+    submitted_at: datetime
+
+
+class CollectorCheckInRequest(BaseModel):
+    collector_instance_id: str
+    collector_version: str
+    capability_tags: list[str] = Field(default_factory=list)
+    max_concurrent_jobs: int
+    current_active_load: int
+    last_known_job_ids: list[str] = Field(default_factory=list)
+    placement: dict[str, str] = Field(default_factory=dict)
+
+
+class CollectorCheckInResponse(BaseModel):
+    collector_instance_id: str
+    registered: bool
+    next_check_in_seconds: int
+
+
+class ClaimWorkRequest(BaseModel):
+    collector_instance_id: str
+    current_load: int
+    available_capacity: int
+    capability_tags: list[str] = Field(default_factory=list)
+    preferred_batch_size: int | None = None
+
+
+class ClaimedJobResponse(BaseModel):
+    job_id: str
+    run_id: str
+    lease_id: str
+    lease_expires_at: str
+    job_kind: str
+    execution_parameters: dict[str, Any] = Field(default_factory=dict)
+    artifact_submission_required: bool = True
+
+
+class ClaimWorkResponse(BaseModel):
+    jobs: list[ClaimedJobResponse]
+
+
+class HeartbeatRequest(BaseModel):
+    collector_instance_id: str
+    lease_id: str
+    current_execution_status: str
+    progress_summary: str | None = None
+
+
+class HeartbeatResponse(BaseModel):
+    lease_id: str
+    lease_expires_at: str
+    accepted: bool
+
+
+class GraphSubmissionRequest(BaseModel):
+    collector_instance_id: str
+    lease_id: str
+    payload: dict[str, Any]
+
+
+class GraphSubmissionResponse(BaseModel):
+    submission_id: str
+    accepted: bool
+
+
+class ResultSubmissionRequest(BaseModel):
+    collector_instance_id: str
+    job_id: str
+    status: str
+    summary: str
+    metrics: dict[str, int | float] = Field(default_factory=dict)
+    artifact_refs: list[str] = Field(default_factory=list)
+
+
+class ResultSubmissionResponse(BaseModel):
+    result_id: str
+    accepted: bool
+
+
+def create_app(repository: ControlPlaneRepository) -> FastAPI:
+    app = FastAPI(title="canonical-discovery")
+    app.state.repository = repository
+    app.state.collector_sessions = {}
+    app.state.graph_submissions = {}
+
+    @app.get("/healthz")
+    def healthz() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.post("/collectors/check-in", response_model=CollectorCheckInResponse)
+    def collector_check_in(request: CollectorCheckInRequest) -> CollectorCheckInResponse:
+        app.state.collector_sessions[request.collector_instance_id] = CollectorSession(
+            collector_instance_id=request.collector_instance_id,
+            collector_version=request.collector_version,
+            capability_tags=tuple(request.capability_tags),
+            max_concurrent_jobs=request.max_concurrent_jobs,
+            current_active_load=request.current_active_load,
+            last_known_job_ids=tuple(request.last_known_job_ids),
+            placement=dict(request.placement),
+        )
+        return CollectorCheckInResponse(
+            collector_instance_id=request.collector_instance_id,
+            registered=True,
+            next_check_in_seconds=CHECK_IN_INTERVAL_SECONDS,
+        )
+
+    @app.post("/collectors/claim-work", response_model=ClaimWorkResponse)
+    def claim_work(request: ClaimWorkRequest) -> ClaimWorkResponse:
+        session = app.state.collector_sessions.get(request.collector_instance_id)
+        if session is None:
+            raise HTTPException(status_code=404, detail="collector session not found")
+
+        available_capacity = max(request.available_capacity, 0)
+        claim_limit = request.preferred_batch_size or available_capacity
+        capability_tags = set(request.capability_tags)
+        claimed_jobs: list[ClaimedJobResponse] = []
+
+        for job in repository.list_jobs(status=JobStatus.QUEUED, service_role="collector"):
+            if available_capacity <= 0 or len(claimed_jobs) >= claim_limit:
+                break
+            if not set(job.required_tags).issubset(capability_tags):
+                continue
+
+            issued_at = datetime.now(UTC)
+            expires_at = issued_at + timedelta(seconds=LEASE_TTL_SECONDS)
+            lease = Lease(
+                lease_id=str(uuid4()),
+                job_id=job.job_id,
+                claimant_id=request.collector_instance_id,
+                issued_at=issued_at,
+                expires_at=expires_at,
+            )
+            repository.save_lease(lease)
+            repository.save_job(
+                Job(
+                    job_id=job.job_id,
+                    run_id=job.run_id,
+                    job_kind=job.job_kind,
+                    service_role=job.service_role,
+                    required_tags=job.required_tags,
+                    priority=job.priority,
+                    status=JobStatus.CLAIMED,
+                    attempt_count=job.attempt_count,
+                )
+            )
+            claimed_jobs.append(
+                ClaimedJobResponse(
+                    job_id=job.job_id,
+                    run_id=job.run_id,
+                    lease_id=lease.lease_id,
+                    lease_expires_at=lease.expires_at.isoformat(),
+                    job_kind=job.job_kind,
+                )
+            )
+            available_capacity -= 1
+
+        return ClaimWorkResponse(jobs=claimed_jobs)
+
+    @app.post("/collectors/heartbeat", response_model=HeartbeatResponse)
+    def heartbeat(request: HeartbeatRequest) -> HeartbeatResponse:
+        lease = repository.get_lease(request.lease_id)
+        if lease is None:
+            raise HTTPException(status_code=404, detail="lease not found")
+
+        updated_lease = Lease(
+            lease_id=lease.lease_id,
+            job_id=lease.job_id,
+            claimant_id=lease.claimant_id,
+            issued_at=lease.issued_at,
+            expires_at=datetime.now(UTC) + timedelta(seconds=LEASE_TTL_SECONDS),
+            last_heartbeat_at=datetime.now(UTC),
+        )
+        repository.save_lease(updated_lease)
+
+        return HeartbeatResponse(
+            lease_id=updated_lease.lease_id,
+            lease_expires_at=updated_lease.expires_at.isoformat(),
+            accepted=True,
+        )
+
+    @app.post("/collectors/graph-submissions", response_model=GraphSubmissionResponse)
+    def graph_submission(request: GraphSubmissionRequest) -> GraphSubmissionResponse:
+        lease = repository.get_lease(request.lease_id)
+        if lease is None:
+            raise HTTPException(status_code=404, detail="lease not found")
+
+        submission = GraphSubmission(
+            submission_id=str(uuid4()),
+            collector_instance_id=request.collector_instance_id,
+            lease_id=request.lease_id,
+            payload=dict(request.payload),
+            submitted_at=datetime.now(UTC),
+        )
+        app.state.graph_submissions[submission.submission_id] = submission
+
+        return GraphSubmissionResponse(submission_id=submission.submission_id, accepted=True)
+
+    @app.post("/collectors/results", response_model=ResultSubmissionResponse)
+    def result_submission(request: ResultSubmissionRequest) -> ResultSubmissionResponse:
+        job = repository.get_job(request.job_id)
+        if job is None:
+            raise HTTPException(status_code=404, detail="job not found")
+
+        result = Result(
+            result_id=str(uuid4()),
+            job_id=request.job_id,
+            status=request.status,
+            summary=request.summary,
+            metrics=dict(request.metrics),
+            artifact_refs=tuple(request.artifact_refs),
+        )
+        repository.save_result(result)
+        repository.save_job(
+            Job(
+                job_id=job.job_id,
+                run_id=job.run_id,
+                job_kind=job.job_kind,
+                service_role=job.service_role,
+                required_tags=job.required_tags,
+                priority=job.priority,
+                status=JobStatus(request.status),
+                attempt_count=job.attempt_count,
+            )
+        )
+
+        return ResultSubmissionResponse(result_id=result.result_id, accepted=True)
+
+    return app
+
+
+app = create_app(SQLiteControlPlaneRepository(":memory:"))

--- a/src/canonical_discovery/control_plane/__init__.py
+++ b/src/canonical_discovery/control_plane/__init__.py
@@ -1,6 +1,8 @@
 """Control-plane runtime models."""
 
 from canonical_discovery.control_plane.models import (
+    CollectorSession,
+    GraphSubmission,
     Heartbeat,
     Job,
     Lease,
@@ -11,6 +13,8 @@ from canonical_discovery.control_plane.models import (
 from canonical_discovery.control_plane.status import JobStatus, RunStatus, TaskStatus
 
 __all__ = [
+    "CollectorSession",
+    "GraphSubmission",
     "Heartbeat",
     "Job",
     "JobStatus",

--- a/src/canonical_discovery/control_plane/models.py
+++ b/src/canonical_discovery/control_plane/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from canonical_discovery.control_plane.status import JobStatus, RunStatus, TaskStatus
@@ -123,3 +123,24 @@ class Result:
             "metrics": dict(self.metrics),
             "artifact_refs": list(self.artifact_refs),
         }
+
+
+@dataclass(frozen=True, slots=True)
+class CollectorSession:
+    collector_instance_id: str
+    collector_version: str
+    capability_tags: tuple[str, ...] = ()
+    max_concurrent_jobs: int = 0
+    current_active_load: int = 0
+    last_known_job_ids: tuple[str, ...] = ()
+    placement: dict[str, str] = field(default_factory=dict)
+    last_check_in_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+
+@dataclass(frozen=True, slots=True)
+class GraphSubmission:
+    submission_id: str
+    collector_instance_id: str
+    lease_id: str
+    payload: dict[str, Any] = field(default_factory=dict)
+    submitted_at: datetime = field(default_factory=lambda: datetime.now(UTC))

--- a/src/canonical_discovery/repository/control_plane.py
+++ b/src/canonical_discovery/repository/control_plane.py
@@ -92,3 +92,14 @@ class ControlPlaneRepository(ABC):
     @abstractmethod
     def get_graph_submission_for_lease(self, lease_id: str) -> GraphSubmission | None:
         raise NotImplementedError
+
+    @abstractmethod
+    def finalize_job_result(
+        self,
+        *,
+        job: Job,
+        lease_id: str,
+        result: Result,
+        next_status: JobStatus,
+    ) -> bool:
+        raise NotImplementedError

--- a/src/canonical_discovery/repository/control_plane.py
+++ b/src/canonical_discovery/repository/control_plane.py
@@ -88,3 +88,7 @@ class ControlPlaneRepository(ABC):
     @abstractmethod
     def get_graph_submission(self, submission_id: str) -> GraphSubmission | None:
         raise NotImplementedError
+
+    @abstractmethod
+    def get_graph_submission_for_lease(self, lease_id: str) -> GraphSubmission | None:
+        raise NotImplementedError

--- a/src/canonical_discovery/repository/control_plane.py
+++ b/src/canonical_discovery/repository/control_plane.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
-from canonical_discovery.control_plane import Job, Lease, Result, Run
+from canonical_discovery.control_plane import Job, JobStatus, Lease, Result, Run
 
 
 class ControlPlaneRepository(ABC):
@@ -24,6 +24,12 @@ class ControlPlaneRepository(ABC):
 
     @abstractmethod
     def get_job(self, job_id: str) -> Job | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def list_jobs(
+        self, *, status: JobStatus | None = None, service_role: str | None = None
+    ) -> list[Job]:
         raise NotImplementedError
 
     @abstractmethod

--- a/src/canonical_discovery/repository/control_plane.py
+++ b/src/canonical_discovery/repository/control_plane.py
@@ -4,7 +4,15 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
-from canonical_discovery.control_plane import Job, JobStatus, Lease, Result, Run
+from canonical_discovery.control_plane import (
+    CollectorSession,
+    GraphSubmission,
+    Job,
+    JobStatus,
+    Lease,
+    Result,
+    Run,
+)
 
 
 class ControlPlaneRepository(ABC):
@@ -33,6 +41,14 @@ class ControlPlaneRepository(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def save_collector_session(self, session: CollectorSession) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_collector_session(self, collector_instance_id: str) -> CollectorSession | None:
+        raise NotImplementedError
+
+    @abstractmethod
     def save_lease(self, lease: Lease) -> None:
         raise NotImplementedError
 
@@ -41,9 +57,21 @@ class ControlPlaneRepository(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def get_lease_for_job(self, job_id: str) -> Lease | None:
+        raise NotImplementedError
+
+    @abstractmethod
     def save_result(self, result: Result) -> None:
         raise NotImplementedError
 
     @abstractmethod
     def get_result(self, result_id: str) -> Result | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def save_graph_submission(self, submission: GraphSubmission) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_graph_submission(self, submission_id: str) -> GraphSubmission | None:
         raise NotImplementedError

--- a/src/canonical_discovery/repository/control_plane.py
+++ b/src/canonical_discovery/repository/control_plane.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from datetime import datetime
 
 from canonical_discovery.control_plane import (
     CollectorSession,
@@ -38,6 +39,18 @@ class ControlPlaneRepository(ABC):
     def list_jobs(
         self, *, status: JobStatus | None = None, service_role: str | None = None
     ) -> list[Job]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def claim_job(
+        self,
+        *,
+        job_id: str,
+        claimant_id: str,
+        lease_id: str,
+        issued_at: datetime,
+        expires_at: datetime,
+    ) -> Lease | None:
         raise NotImplementedError
 
     @abstractmethod

--- a/src/canonical_discovery/repository/sqlite_control_plane.py
+++ b/src/canonical_discovery/repository/sqlite_control_plane.py
@@ -405,6 +405,25 @@ class SQLiteControlPlaneRepository(ControlPlaneRepository):
             submitted_at=datetime.fromisoformat(row[4]),
         )
 
+    def get_graph_submission_for_lease(self, lease_id: str) -> GraphSubmission | None:
+        row = self._fetch_one(
+            """
+            SELECT submission_id, collector_instance_id, lease_id, payload, submitted_at
+            FROM graph_submissions WHERE lease_id = ?
+            """,
+            (lease_id,),
+        )
+        if row is None:
+            return None
+
+        return GraphSubmission(
+            submission_id=row[0],
+            collector_instance_id=row[1],
+            lease_id=row[2],
+            payload=json.loads(row[3]),
+            submitted_at=datetime.fromisoformat(row[4]),
+        )
+
     def _initialize_schema(self) -> None:
         with self._connection() as connection:
             connection.executescript(
@@ -460,7 +479,7 @@ class SQLiteControlPlaneRepository(ControlPlaneRepository):
                 CREATE TABLE IF NOT EXISTS graph_submissions (
                     submission_id TEXT PRIMARY KEY,
                     collector_instance_id TEXT NOT NULL,
-                    lease_id TEXT NOT NULL REFERENCES leases(lease_id),
+                    lease_id TEXT NOT NULL UNIQUE REFERENCES leases(lease_id),
                     payload TEXT NOT NULL,
                     submitted_at TEXT NOT NULL
                 );

--- a/src/canonical_discovery/repository/sqlite_control_plane.py
+++ b/src/canonical_discovery/repository/sqlite_control_plane.py
@@ -7,7 +7,16 @@ import sqlite3
 from contextlib import contextmanager
 from datetime import datetime
 
-from canonical_discovery.control_plane import Job, JobStatus, Lease, Result, Run, RunStatus
+from canonical_discovery.control_plane import (
+    CollectorSession,
+    GraphSubmission,
+    Job,
+    JobStatus,
+    Lease,
+    Result,
+    Run,
+    RunStatus,
+)
 from canonical_discovery.repository.control_plane import ControlPlaneRepository
 
 
@@ -151,6 +160,57 @@ class SQLiteControlPlaneRepository(ControlPlaneRepository):
             for row in rows
         ]
 
+    def save_collector_session(self, session: CollectorSession) -> None:
+        with self._connection() as connection:
+            connection.execute(
+                """
+                INSERT OR REPLACE INTO collector_sessions (
+                    collector_instance_id,
+                    collector_version,
+                    capability_tags,
+                    max_concurrent_jobs,
+                    current_active_load,
+                    last_known_job_ids,
+                    placement,
+                    last_check_in_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    session.collector_instance_id,
+                    session.collector_version,
+                    json.dumps(list(session.capability_tags)),
+                    session.max_concurrent_jobs,
+                    session.current_active_load,
+                    json.dumps(list(session.last_known_job_ids)),
+                    json.dumps(session.placement),
+                    session.last_check_in_at.isoformat(),
+                ),
+            )
+
+    def get_collector_session(self, collector_instance_id: str) -> CollectorSession | None:
+        row = self._fetch_one(
+            """
+            SELECT collector_instance_id, collector_version, capability_tags,
+                   max_concurrent_jobs, current_active_load, last_known_job_ids,
+                   placement, last_check_in_at
+            FROM collector_sessions WHERE collector_instance_id = ?
+            """,
+            (collector_instance_id,),
+        )
+        if row is None:
+            return None
+
+        return CollectorSession(
+            collector_instance_id=row[0],
+            collector_version=row[1],
+            capability_tags=tuple(json.loads(row[2])),
+            max_concurrent_jobs=row[3],
+            current_active_load=row[4],
+            last_known_job_ids=tuple(json.loads(row[5])),
+            placement=json.loads(row[6]),
+            last_check_in_at=datetime.fromisoformat(row[7]),
+        )
+
     def save_lease(self, lease: Lease) -> None:
         with self._connection() as connection:
             connection.execute(
@@ -181,6 +241,28 @@ class SQLiteControlPlaneRepository(ControlPlaneRepository):
             FROM leases WHERE lease_id = ?
             """,
             (lease_id,),
+        )
+        if row is None:
+            return None
+
+        return Lease(
+            lease_id=row[0],
+            job_id=row[1],
+            claimant_id=row[2],
+            issued_at=datetime.fromisoformat(row[3]),
+            expires_at=datetime.fromisoformat(row[4]),
+            last_heartbeat_at=datetime.fromisoformat(row[5]) if row[5] is not None else None,
+        )
+
+    def get_lease_for_job(self, job_id: str) -> Lease | None:
+        row = self._fetch_one(
+            """
+            SELECT lease_id, job_id, claimant_id, issued_at, expires_at, last_heartbeat_at
+            FROM leases WHERE job_id = ?
+            ORDER BY issued_at DESC
+            LIMIT 1
+            """,
+            (job_id,),
         )
         if row is None:
             return None
@@ -237,6 +319,46 @@ class SQLiteControlPlaneRepository(ControlPlaneRepository):
             artifact_refs=tuple(json.loads(row[5])),
         )
 
+    def save_graph_submission(self, submission: GraphSubmission) -> None:
+        with self._connection() as connection:
+            connection.execute(
+                """
+                INSERT OR REPLACE INTO graph_submissions (
+                    submission_id,
+                    collector_instance_id,
+                    lease_id,
+                    payload,
+                    submitted_at
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    submission.submission_id,
+                    submission.collector_instance_id,
+                    submission.lease_id,
+                    json.dumps(submission.payload),
+                    submission.submitted_at.isoformat(),
+                ),
+            )
+
+    def get_graph_submission(self, submission_id: str) -> GraphSubmission | None:
+        row = self._fetch_one(
+            """
+            SELECT submission_id, collector_instance_id, lease_id, payload, submitted_at
+            FROM graph_submissions WHERE submission_id = ?
+            """,
+            (submission_id,),
+        )
+        if row is None:
+            return None
+
+        return GraphSubmission(
+            submission_id=row[0],
+            collector_instance_id=row[1],
+            lease_id=row[2],
+            payload=json.loads(row[3]),
+            submitted_at=datetime.fromisoformat(row[4]),
+        )
+
     def _initialize_schema(self) -> None:
         with self._connection() as connection:
             connection.executescript(
@@ -276,6 +398,25 @@ class SQLiteControlPlaneRepository(ControlPlaneRepository):
                     summary TEXT NOT NULL,
                     metrics TEXT NOT NULL,
                     artifact_refs TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS collector_sessions (
+                    collector_instance_id TEXT PRIMARY KEY,
+                    collector_version TEXT NOT NULL,
+                    capability_tags TEXT NOT NULL,
+                    max_concurrent_jobs INTEGER NOT NULL,
+                    current_active_load INTEGER NOT NULL,
+                    last_known_job_ids TEXT NOT NULL,
+                    placement TEXT NOT NULL,
+                    last_check_in_at TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS graph_submissions (
+                    submission_id TEXT PRIMARY KEY,
+                    collector_instance_id TEXT NOT NULL,
+                    lease_id TEXT NOT NULL REFERENCES leases(lease_id),
+                    payload TEXT NOT NULL,
+                    submitted_at TEXT NOT NULL
                 );
                 """
             )

--- a/src/canonical_discovery/repository/sqlite_control_plane.py
+++ b/src/canonical_discovery/repository/sqlite_control_plane.py
@@ -114,6 +114,43 @@ class SQLiteControlPlaneRepository(ControlPlaneRepository):
             attempt_count=row[7],
         )
 
+    def list_jobs(
+        self, *, status: JobStatus | None = None, service_role: str | None = None
+    ) -> list[Job]:
+        where_clauses = []
+        params: list[str] = []
+
+        if status is not None:
+            where_clauses.append("status = ?")
+            params.append(status.value)
+        if service_role is not None:
+            where_clauses.append("service_role = ?")
+            params.append(service_role)
+
+        where_sql = f" WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
+        query = (
+            "SELECT job_id, run_id, job_kind, service_role, required_tags, "
+            "priority, status, attempt_count "
+            f"FROM jobs{where_sql}"
+        )
+
+        with self._connection() as connection:
+            rows = connection.execute(query, tuple(params)).fetchall()
+
+        return [
+            Job(
+                job_id=row[0],
+                run_id=row[1],
+                job_kind=row[2],
+                service_role=row[3],
+                required_tags=tuple(json.loads(row[4])),
+                priority=row[5],
+                status=JobStatus(row[6]),
+                attempt_count=row[7],
+            )
+            for row in rows
+        ]
+
     def save_lease(self, lease: Lease) -> None:
         with self._connection() as connection:
             connection.execute(

--- a/src/canonical_discovery/repository/sqlite_control_plane.py
+++ b/src/canonical_discovery/repository/sqlite_control_plane.py
@@ -424,6 +424,57 @@ class SQLiteControlPlaneRepository(ControlPlaneRepository):
             submitted_at=datetime.fromisoformat(row[4]),
         )
 
+    def finalize_job_result(
+        self,
+        *,
+        job: Job,
+        lease_id: str,
+        result: Result,
+        next_status: JobStatus,
+    ) -> bool:
+        with self._connection() as connection:
+            lease_row = connection.execute(
+                "SELECT lease_id FROM leases WHERE lease_id = ? AND job_id = ?",
+                (lease_id, job.job_id),
+            ).fetchone()
+            if lease_row is None:
+                return False
+
+            existing_result = connection.execute(
+                "SELECT result_id FROM results WHERE job_id = ?",
+                (job.job_id,),
+            ).fetchone()
+            if existing_result is not None:
+                return False
+
+            connection.execute(
+                """
+                INSERT INTO results (
+                    result_id,
+                    job_id,
+                    status,
+                    summary,
+                    metrics,
+                    artifact_refs
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    result.result_id,
+                    result.job_id,
+                    result.status,
+                    result.summary,
+                    json.dumps(result.metrics),
+                    json.dumps(list(result.artifact_refs)),
+                ),
+            )
+            connection.execute(
+                "UPDATE jobs SET status = ? WHERE job_id = ?",
+                (next_status.value, job.job_id),
+            )
+            connection.execute("DELETE FROM leases WHERE lease_id = ?", (lease_id,))
+
+        return True
+
     def _initialize_schema(self) -> None:
         with self._connection() as connection:
             connection.executescript(

--- a/src/canonical_discovery/repository/sqlite_control_plane.py
+++ b/src/canonical_discovery/repository/sqlite_control_plane.py
@@ -160,6 +160,52 @@ class SQLiteControlPlaneRepository(ControlPlaneRepository):
             for row in rows
         ]
 
+    def claim_job(
+        self,
+        *,
+        job_id: str,
+        claimant_id: str,
+        lease_id: str,
+        issued_at: datetime,
+        expires_at: datetime,
+    ) -> Lease | None:
+        with self._connection() as connection:
+            cursor = connection.execute(
+                "UPDATE jobs SET status = ? WHERE job_id = ? AND status = ?",
+                (JobStatus.CLAIMED.value, job_id, JobStatus.QUEUED.value),
+            )
+            if cursor.rowcount != 1:
+                return None
+
+            connection.execute(
+                """
+                INSERT OR REPLACE INTO leases (
+                    lease_id,
+                    job_id,
+                    claimant_id,
+                    issued_at,
+                    expires_at,
+                    last_heartbeat_at
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    lease_id,
+                    job_id,
+                    claimant_id,
+                    issued_at.isoformat(),
+                    expires_at.isoformat(),
+                    None,
+                ),
+            )
+
+        return Lease(
+            lease_id=lease_id,
+            job_id=job_id,
+            claimant_id=claimant_id,
+            issued_at=issued_at,
+            expires_at=expires_at,
+        )
+
     def save_collector_session(self, session: CollectorSession) -> None:
         with self._connection() as connection:
             connection.execute(

--- a/tests/test_collector_api.py
+++ b/tests/test_collector_api.py
@@ -117,6 +117,41 @@ class CollectorApiTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 404)
 
+    def test_heartbeat_rejects_claimant_mismatch(self) -> None:
+        self.client.post(
+            "/collectors/check-in",
+            json={
+                "collector_instance_id": "collector-1",
+                "collector_version": "1.0",
+                "capability_tags": ["vmware"],
+                "max_concurrent_jobs": 2,
+                "current_active_load": 0,
+                "last_known_job_ids": [],
+                "placement": {},
+            },
+        )
+        claim_response = self.client.post(
+            "/collectors/claim-work",
+            json={
+                "collector_instance_id": "collector-1",
+                "current_load": 0,
+                "available_capacity": 1,
+                "capability_tags": ["vmware"],
+            },
+        )
+        lease_id = claim_response.json()["jobs"][0]["lease_id"]
+
+        response = self.client.post(
+            "/collectors/heartbeat",
+            json={
+                "collector_instance_id": "collector-2",
+                "lease_id": lease_id,
+                "current_execution_status": "running",
+            },
+        )
+
+        self.assertEqual(response.status_code, 403)
+
     def test_result_submission_persists_result_and_updates_job(self) -> None:
         self.client.post(
             "/collectors/check-in",
@@ -157,6 +192,78 @@ class CollectorApiTests(unittest.TestCase):
         result_id = response.json()["result_id"]
         self.assertEqual(self.repository.get_result(result_id).summary, "done")
         self.assertEqual(self.repository.get_job("job-1").status, JobStatus.SUCCEEDED)
+
+    def test_result_submission_rejects_invalid_status_before_persisting_result(self) -> None:
+        self.client.post(
+            "/collectors/check-in",
+            json={
+                "collector_instance_id": "collector-1",
+                "collector_version": "1.0",
+                "capability_tags": ["vmware"],
+                "max_concurrent_jobs": 2,
+                "current_active_load": 0,
+                "last_known_job_ids": [],
+                "placement": {},
+            },
+        )
+        self.client.post(
+            "/collectors/claim-work",
+            json={
+                "collector_instance_id": "collector-1",
+                "current_load": 0,
+                "available_capacity": 1,
+                "capability_tags": ["vmware"],
+            },
+        )
+
+        response = self.client.post(
+            "/collectors/results",
+            json={
+                "collector_instance_id": "collector-1",
+                "job_id": "job-1",
+                "status": "not-a-status",
+                "summary": "done",
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_graph_submission_is_persisted_in_repository(self) -> None:
+        self.client.post(
+            "/collectors/check-in",
+            json={
+                "collector_instance_id": "collector-1",
+                "collector_version": "1.0",
+                "capability_tags": ["vmware"],
+                "max_concurrent_jobs": 2,
+                "current_active_load": 0,
+                "last_known_job_ids": [],
+                "placement": {},
+            },
+        )
+        claim_response = self.client.post(
+            "/collectors/claim-work",
+            json={
+                "collector_instance_id": "collector-1",
+                "current_load": 0,
+                "available_capacity": 1,
+                "capability_tags": ["vmware"],
+            },
+        )
+        lease_id = claim_response.json()["jobs"][0]["lease_id"]
+
+        response = self.client.post(
+            "/collectors/graph-submissions",
+            json={
+                "collector_instance_id": "collector-1",
+                "lease_id": lease_id,
+                "payload": {"nodes": []},
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        submission_id = response.json()["submission_id"]
+        self.assertEqual(self.repository.get_graph_submission(submission_id).lease_id, lease_id)
 
 
 if __name__ == "__main__":

--- a/tests/test_collector_api.py
+++ b/tests/test_collector_api.py
@@ -1,0 +1,163 @@
+"""Tests for the collector lifecycle API."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+
+from canonical_discovery.api import create_app
+from canonical_discovery.control_plane import Job, JobStatus, Run, RunStatus
+from canonical_discovery.repository import SQLiteControlPlaneRepository
+
+
+class CollectorApiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_db = tempfile.NamedTemporaryFile()
+        self.repository = SQLiteControlPlaneRepository(self.temp_db.name)
+        self.client = TestClient(create_app(self.repository))
+
+        self.repository.save_run(
+            Run(
+                run_id="run-1",
+                created_at=datetime(2026, 4, 30, 12, 0, 0),
+                trigger_type="manual",
+                requested_mode="discovery_only",
+                status=RunStatus.QUEUED,
+            )
+        )
+        self.repository.save_job(
+            Job(
+                job_id="job-1",
+                run_id="run-1",
+                job_kind="collect_source",
+                service_role="collector",
+                required_tags=("vmware",),
+                status=JobStatus.QUEUED,
+            )
+        )
+
+    def tearDown(self) -> None:
+        self.temp_db.close()
+
+    def test_health_endpoint(self) -> None:
+        response = self.client.get("/healthz")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "ok"})
+
+    def test_check_in_registers_collector(self) -> None:
+        response = self.client.post(
+            "/collectors/check-in",
+            json={
+                "collector_instance_id": "collector-1",
+                "collector_version": "1.0",
+                "capability_tags": ["vmware"],
+                "max_concurrent_jobs": 2,
+                "current_active_load": 0,
+                "last_known_job_ids": [],
+                "placement": {},
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["registered"])
+
+    def test_claim_work_returns_matching_queued_job(self) -> None:
+        self.client.post(
+            "/collectors/check-in",
+            json={
+                "collector_instance_id": "collector-1",
+                "collector_version": "1.0",
+                "capability_tags": ["vmware"],
+                "max_concurrent_jobs": 2,
+                "current_active_load": 0,
+                "last_known_job_ids": [],
+                "placement": {},
+            },
+        )
+
+        response = self.client.post(
+            "/collectors/claim-work",
+            json={
+                "collector_instance_id": "collector-1",
+                "current_load": 0,
+                "available_capacity": 1,
+                "capability_tags": ["vmware"],
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()["jobs"]), 1)
+        self.assertEqual(self.repository.get_job("job-1").status, JobStatus.CLAIMED)
+
+    def test_heartbeat_requires_existing_lease(self) -> None:
+        response = self.client.post(
+            "/collectors/heartbeat",
+            json={
+                "collector_instance_id": "collector-1",
+                "lease_id": "missing",
+                "current_execution_status": "running",
+            },
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_graph_submission_requires_existing_lease(self) -> None:
+        response = self.client.post(
+            "/collectors/graph-submissions",
+            json={
+                "collector_instance_id": "collector-1",
+                "lease_id": "missing",
+                "payload": {"nodes": []},
+            },
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_result_submission_persists_result_and_updates_job(self) -> None:
+        self.client.post(
+            "/collectors/check-in",
+            json={
+                "collector_instance_id": "collector-1",
+                "collector_version": "1.0",
+                "capability_tags": ["vmware"],
+                "max_concurrent_jobs": 2,
+                "current_active_load": 0,
+                "last_known_job_ids": [],
+                "placement": {},
+            },
+        )
+        claim_response = self.client.post(
+            "/collectors/claim-work",
+            json={
+                "collector_instance_id": "collector-1",
+                "current_load": 0,
+                "available_capacity": 1,
+                "capability_tags": ["vmware"],
+            },
+        )
+        self.assertEqual(claim_response.status_code, 200)
+
+        response = self.client.post(
+            "/collectors/results",
+            json={
+                "collector_instance_id": "collector-1",
+                "job_id": "job-1",
+                "status": "succeeded",
+                "summary": "done",
+                "metrics": {"nodes": 4},
+                "artifact_refs": ["artifact-1"],
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        result_id = response.json()["result_id"]
+        self.assertEqual(self.repository.get_result(result_id).summary, "done")
+        self.assertEqual(self.repository.get_job("job-1").status, JobStatus.SUCCEEDED)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_collector_api.py
+++ b/tests/test_collector_api.py
@@ -93,6 +93,55 @@ class CollectorApiTests(unittest.TestCase):
         self.assertEqual(len(response.json()["jobs"]), 1)
         self.assertEqual(self.repository.get_job("job-1").status, JobStatus.CLAIMED)
 
+    def test_claim_work_does_not_double_lease_same_job(self) -> None:
+        self.client.post(
+            "/collectors/check-in",
+            json={
+                "collector_instance_id": "collector-1",
+                "collector_version": "1.0",
+                "capability_tags": ["vmware"],
+                "max_concurrent_jobs": 2,
+                "current_active_load": 0,
+                "last_known_job_ids": [],
+                "placement": {},
+            },
+        )
+        self.client.post(
+            "/collectors/check-in",
+            json={
+                "collector_instance_id": "collector-2",
+                "collector_version": "1.0",
+                "capability_tags": ["vmware"],
+                "max_concurrent_jobs": 2,
+                "current_active_load": 0,
+                "last_known_job_ids": [],
+                "placement": {},
+            },
+        )
+
+        first = self.client.post(
+            "/collectors/claim-work",
+            json={
+                "collector_instance_id": "collector-1",
+                "current_load": 0,
+                "available_capacity": 1,
+                "capability_tags": ["vmware"],
+            },
+        )
+        second = self.client.post(
+            "/collectors/claim-work",
+            json={
+                "collector_instance_id": "collector-2",
+                "current_load": 0,
+                "available_capacity": 1,
+                "capability_tags": ["vmware"],
+            },
+        )
+
+        self.assertEqual(len(first.json()["jobs"]), 1)
+        self.assertEqual(second.status_code, 200)
+        self.assertEqual(second.json()["jobs"], [])
+
     def test_heartbeat_requires_existing_lease(self) -> None:
         response = self.client.post(
             "/collectors/heartbeat",
@@ -222,6 +271,41 @@ class CollectorApiTests(unittest.TestCase):
                 "collector_instance_id": "collector-1",
                 "job_id": "job-1",
                 "status": "not-a-status",
+                "summary": "done",
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_result_submission_rejects_non_terminal_status(self) -> None:
+        self.client.post(
+            "/collectors/check-in",
+            json={
+                "collector_instance_id": "collector-1",
+                "collector_version": "1.0",
+                "capability_tags": ["vmware"],
+                "max_concurrent_jobs": 2,
+                "current_active_load": 0,
+                "last_known_job_ids": [],
+                "placement": {},
+            },
+        )
+        self.client.post(
+            "/collectors/claim-work",
+            json={
+                "collector_instance_id": "collector-1",
+                "current_load": 0,
+                "available_capacity": 1,
+                "capability_tags": ["vmware"],
+            },
+        )
+
+        response = self.client.post(
+            "/collectors/results",
+            json={
+                "collector_instance_id": "collector-1",
+                "job_id": "job-1",
+                "status": "queued",
                 "summary": "done",
             },
         )

--- a/tests/test_collector_api.py
+++ b/tests/test_collector_api.py
@@ -242,6 +242,52 @@ class CollectorApiTests(unittest.TestCase):
         result_id = response.json()["result_id"]
         self.assertEqual(self.repository.get_result(result_id).summary, "done")
         self.assertEqual(self.repository.get_job("job-1").status, JobStatus.SUCCEEDED)
+        self.assertIsNone(self.repository.get_lease(claim_response.json()["jobs"][0]["lease_id"]))
+
+    def test_heartbeat_rejects_completed_job_lease(self) -> None:
+        self.client.post(
+            "/collectors/check-in",
+            json={
+                "collector_instance_id": "collector-1",
+                "collector_version": "1.0",
+                "capability_tags": ["vmware"],
+                "max_concurrent_jobs": 2,
+                "current_active_load": 0,
+                "last_known_job_ids": [],
+                "placement": {},
+            },
+        )
+        claim_response = self.client.post(
+            "/collectors/claim-work",
+            json={
+                "collector_instance_id": "collector-1",
+                "current_load": 0,
+                "available_capacity": 1,
+                "capability_tags": ["vmware"],
+            },
+        )
+        lease_id = claim_response.json()["jobs"][0]["lease_id"]
+        self.client.post(
+            "/collectors/results",
+            json={
+                "collector_instance_id": "collector-1",
+                "lease_id": lease_id,
+                "job_id": "job-1",
+                "status": "succeeded",
+                "summary": "done",
+            },
+        )
+
+        response = self.client.post(
+            "/collectors/heartbeat",
+            json={
+                "collector_instance_id": "collector-1",
+                "lease_id": lease_id,
+                "current_execution_status": "running",
+            },
+        )
+
+        self.assertEqual(response.status_code, 404)
 
     def test_result_submission_rejects_invalid_status_before_persisting_result(self) -> None:
         self.client.post(
@@ -398,6 +444,51 @@ class CollectorApiTests(unittest.TestCase):
         self.assertEqual(first.status_code, 200)
         self.assertEqual(second.status_code, 200)
         self.assertEqual(first.json()["submission_id"], second.json()["submission_id"])
+
+    def test_graph_submission_rejects_completed_job_lease(self) -> None:
+        self.client.post(
+            "/collectors/check-in",
+            json={
+                "collector_instance_id": "collector-1",
+                "collector_version": "1.0",
+                "capability_tags": ["vmware"],
+                "max_concurrent_jobs": 2,
+                "current_active_load": 0,
+                "last_known_job_ids": [],
+                "placement": {},
+            },
+        )
+        claim_response = self.client.post(
+            "/collectors/claim-work",
+            json={
+                "collector_instance_id": "collector-1",
+                "current_load": 0,
+                "available_capacity": 1,
+                "capability_tags": ["vmware"],
+            },
+        )
+        lease_id = claim_response.json()["jobs"][0]["lease_id"]
+        self.client.post(
+            "/collectors/results",
+            json={
+                "collector_instance_id": "collector-1",
+                "lease_id": lease_id,
+                "job_id": "job-1",
+                "status": "succeeded",
+                "summary": "done",
+            },
+        )
+
+        response = self.client.post(
+            "/collectors/graph-submissions",
+            json={
+                "collector_instance_id": "collector-1",
+                "lease_id": lease_id,
+                "payload": {"nodes": []},
+            },
+        )
+
+        self.assertEqual(response.status_code, 404)
 
     def test_result_submission_rejects_mismatched_lease(self) -> None:
         self.client.post(

--- a/tests/test_collector_api.py
+++ b/tests/test_collector_api.py
@@ -229,6 +229,7 @@ class CollectorApiTests(unittest.TestCase):
             "/collectors/results",
             json={
                 "collector_instance_id": "collector-1",
+                "lease_id": claim_response.json()["jobs"][0]["lease_id"],
                 "job_id": "job-1",
                 "status": "succeeded",
                 "summary": "done",
@@ -264,11 +265,13 @@ class CollectorApiTests(unittest.TestCase):
                 "capability_tags": ["vmware"],
             },
         )
+        lease_id = self.repository.get_lease_for_job("job-1").lease_id
 
         response = self.client.post(
             "/collectors/results",
             json={
                 "collector_instance_id": "collector-1",
+                "lease_id": lease_id,
                 "job_id": "job-1",
                 "status": "not-a-status",
                 "summary": "done",
@@ -299,11 +302,13 @@ class CollectorApiTests(unittest.TestCase):
                 "capability_tags": ["vmware"],
             },
         )
+        lease_id = self.repository.get_lease_for_job("job-1").lease_id
 
         response = self.client.post(
             "/collectors/results",
             json={
                 "collector_instance_id": "collector-1",
+                "lease_id": lease_id,
                 "job_id": "job-1",
                 "status": "queued",
                 "summary": "done",
@@ -348,6 +353,87 @@ class CollectorApiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         submission_id = response.json()["submission_id"]
         self.assertEqual(self.repository.get_graph_submission(submission_id).lease_id, lease_id)
+
+    def test_graph_submission_is_idempotent_per_lease(self) -> None:
+        self.client.post(
+            "/collectors/check-in",
+            json={
+                "collector_instance_id": "collector-1",
+                "collector_version": "1.0",
+                "capability_tags": ["vmware"],
+                "max_concurrent_jobs": 2,
+                "current_active_load": 0,
+                "last_known_job_ids": [],
+                "placement": {},
+            },
+        )
+        claim_response = self.client.post(
+            "/collectors/claim-work",
+            json={
+                "collector_instance_id": "collector-1",
+                "current_load": 0,
+                "available_capacity": 1,
+                "capability_tags": ["vmware"],
+            },
+        )
+        lease_id = claim_response.json()["jobs"][0]["lease_id"]
+
+        first = self.client.post(
+            "/collectors/graph-submissions",
+            json={
+                "collector_instance_id": "collector-1",
+                "lease_id": lease_id,
+                "payload": {"nodes": []},
+            },
+        )
+        second = self.client.post(
+            "/collectors/graph-submissions",
+            json={
+                "collector_instance_id": "collector-1",
+                "lease_id": lease_id,
+                "payload": {"nodes": []},
+            },
+        )
+
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(second.status_code, 200)
+        self.assertEqual(first.json()["submission_id"], second.json()["submission_id"])
+
+    def test_result_submission_rejects_mismatched_lease(self) -> None:
+        self.client.post(
+            "/collectors/check-in",
+            json={
+                "collector_instance_id": "collector-1",
+                "collector_version": "1.0",
+                "capability_tags": ["vmware"],
+                "max_concurrent_jobs": 2,
+                "current_active_load": 0,
+                "last_known_job_ids": [],
+                "placement": {},
+            },
+        )
+        self.client.post(
+            "/collectors/claim-work",
+            json={
+                "collector_instance_id": "collector-1",
+                "current_load": 0,
+                "available_capacity": 1,
+                "capability_tags": ["vmware"],
+            },
+        )
+
+        response = self.client.post(
+            "/collectors/results",
+            json={
+                "collector_instance_id": "collector-1",
+                "lease_id": "other-lease",
+                "job_id": "job-1",
+                "status": "succeeded",
+                "summary": "done",
+            },
+        )
+
+        self.assertEqual(response.status_code, 409)
 
 
 if __name__ == "__main__":

--- a/tests/test_sqlite_control_plane_repository.py
+++ b/tests/test_sqlite_control_plane_repository.py
@@ -187,6 +187,61 @@ class SQLiteControlPlaneRepositoryTests(unittest.TestCase):
         self.assertEqual(repository.get_collector_session("collector-a"), session)
         self.assertEqual(repository.get_graph_submission("submission-1"), submission)
 
+    def test_finalize_job_result_is_atomic_and_single_use(self) -> None:
+        repository = SQLiteControlPlaneRepository(":memory:")
+
+        run = Run(
+            run_id="run-1",
+            created_at=datetime(2026, 4, 30, 12, 0, 0),
+            trigger_type="manual",
+            requested_mode="discovery_only",
+            status=RunStatus.QUEUED,
+        )
+        job = Job(
+            job_id="job-1",
+            run_id="run-1",
+            job_kind="collect_source",
+            service_role="collector",
+            status=JobStatus.CLAIMED,
+        )
+        lease = Lease(
+            lease_id="lease-1",
+            job_id="job-1",
+            claimant_id="collector-a",
+            issued_at=datetime(2026, 4, 30, 12, 0, 0),
+            expires_at=datetime(2026, 4, 30, 12, 5, 0),
+        )
+        result = Result(
+            result_id="result-1",
+            job_id="job-1",
+            status="succeeded",
+            summary="collector finished",
+        )
+
+        repository.save_run(run)
+        repository.save_job(job)
+        repository.save_lease(lease)
+
+        self.assertTrue(
+            repository.finalize_job_result(
+                job=job,
+                lease_id="lease-1",
+                result=result,
+                next_status=JobStatus.SUCCEEDED,
+            )
+        )
+        self.assertEqual(repository.get_job("job-1").status, JobStatus.SUCCEEDED)
+        self.assertEqual(repository.get_result("result-1"), result)
+        self.assertIsNone(repository.get_lease("lease-1"))
+        self.assertFalse(
+            repository.finalize_job_result(
+                job=job,
+                lease_id="lease-1",
+                result=result,
+                next_status=JobStatus.SUCCEEDED,
+            )
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sqlite_control_plane_repository.py
+++ b/tests/test_sqlite_control_plane_repository.py
@@ -7,7 +7,16 @@ import tempfile
 import unittest
 from datetime import datetime
 
-from canonical_discovery.control_plane import Job, JobStatus, Lease, Result, Run, RunStatus
+from canonical_discovery.control_plane import (
+    CollectorSession,
+    GraphSubmission,
+    Job,
+    JobStatus,
+    Lease,
+    Result,
+    Run,
+    RunStatus,
+)
 from canonical_discovery.repository import SQLiteControlPlaneRepository
 
 
@@ -67,6 +76,8 @@ class SQLiteControlPlaneRepositoryTests(unittest.TestCase):
             self.assertIsNone(repository.get_job("missing"))
             self.assertIsNone(repository.get_lease("missing"))
             self.assertIsNone(repository.get_result("missing"))
+            self.assertIsNone(repository.get_collector_session("missing"))
+            self.assertIsNone(repository.get_graph_submission("missing"))
 
     def test_in_memory_database_supports_round_trip(self) -> None:
         repository = SQLiteControlPlaneRepository(":memory:")
@@ -125,6 +136,56 @@ class SQLiteControlPlaneRepositoryTests(unittest.TestCase):
 
             with self.assertRaises(sqlite3.IntegrityError):
                 repository.save_result(result)
+
+    def test_round_trip_collector_session_and_graph_submission(self) -> None:
+        repository = SQLiteControlPlaneRepository(":memory:")
+
+        run = Run(
+            run_id="run-1",
+            created_at=datetime(2026, 4, 30, 12, 0, 0),
+            trigger_type="manual",
+            requested_mode="discovery_only",
+            status=RunStatus.QUEUED,
+        )
+        job = Job(
+            job_id="job-1",
+            run_id="run-1",
+            job_kind="collect_source",
+            service_role="collector",
+        )
+        lease = Lease(
+            lease_id="lease-1",
+            job_id="job-1",
+            claimant_id="collector-a",
+            issued_at=datetime(2026, 4, 30, 12, 0, 0),
+            expires_at=datetime(2026, 4, 30, 12, 5, 0),
+        )
+        session = CollectorSession(
+            collector_instance_id="collector-a",
+            collector_version="1.0",
+            capability_tags=("vmware",),
+            max_concurrent_jobs=2,
+            current_active_load=1,
+            last_known_job_ids=("job-1",),
+            placement={"region": "lab"},
+            last_check_in_at=datetime(2026, 4, 30, 12, 0, 0),
+        )
+        submission = GraphSubmission(
+            submission_id="submission-1",
+            collector_instance_id="collector-a",
+            lease_id="lease-1",
+            payload={"nodes": []},
+            submitted_at=datetime(2026, 4, 30, 12, 1, 0),
+        )
+
+        repository.save_run(run)
+        repository.save_job(job)
+        repository.save_lease(lease)
+        repository.save_collector_session(session)
+        repository.save_graph_submission(submission)
+
+        self.assertEqual(repository.get_collector_session("collector-a"), session)
+        self.assertEqual(repository.get_graph_submission("submission-1"), submission)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a real FastAPI application with a gunicorn/uvicorn runtime entrypoint
- implement minimal collector lifecycle endpoints for check-in, claim-work, heartbeat, graph submission, and result submission
- extend the control-plane repository with job listing and add API tests for the collector lifecycle flow

## Validation
- `docker compose build app`
- `docker compose run --rm app sh -lc "export PATH=/opt/poetry/bin:$PATH && poetry install --with dev && poetry run ruff format --check . && poetry run ruff check . && PYTHONPATH=src poetry run pytest"`

Closes #24